### PR TITLE
Fix pr94/pdk2

### DIFF
--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -334,7 +334,7 @@ solana logs <PROGRAM_ID>
 
 With the test validator still running, try invoking your program using the client-side script [here](https://github.com/Unboxed-Software/solana-hello-world-client).
 
-Replace the program ID in `index.ts` with the one from the program you just deployed, then run `npm install` followed by `npm start`. This will return a Solana Explorer URL. Copy the URL into the browser to look up the transaction on Solana Explorer and check that “Hello, World!” was printed to the program log. Alternatively, you can view the program logs in the terminal where you ran the `solana logs` command.
+Replace the program ID in `index.ts` with the one from the program you just deployed, then run `npm install` followed by `npm start`. This will return a Solana Explorer URL. Copy the URL into the browser to look up the transaction on Solana Explorer and check that “Hello, world!” was printed to the program log. Alternatively, you can view the program logs in the terminal where you ran the `solana logs` command.
 
 And that's it! You've just created and deployed your first program from a local development environment.
 

--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -290,7 +290,7 @@ pub fn process_instruction(
 
 ### 3. Run a local test validator
 
-With your program written, let's make sure our Solana CLI configuration points to localhost by using the `solana config set --url' command.
+With your program written, let's make sure our Solana CLI configuration points to localhost by using the `solana config set --url` command.
 
 ```bash
 solana config set --url localhost

--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -134,7 +134,7 @@ solana config set --keypair ~/<FILE_PATH>
 
 You'll often find it helpful to run a local validator for testing and debugging rather than deploying to Devnet.
 
-You can run a local test validator using the `solana-test-validator` command. This command creates and ongoing process that will require its own command line window.
+You can run a local test validator using the `solana-test-validator` command. This command creates an ongoing process that will require its own command line window.
 
 ### Stream program logs
 


### PR DESCRIPTION
@jamesrp13 a couple minor things in the commits.

One suggestions, on line 141 in the first sentence, I wonder if it's enough to just say "console"? e.g.

> It's often helpful to open a new console and run the `solana logs` command alongside the test validator.

Rather than:

> It's often helpful to open a new **command line tab or window** and run the `solana logs` command alongside the test validator.