### PR TITLE
Fix borshAccountSchema ordering

### DIFF
--- a/content/deserialize-custom-data.md
+++ b/content/deserialize-custom-data.md
@@ -189,8 +189,8 @@ export class Movie {
 
 	static borshAccountSchema = borsh.struct([
 		borsh.bool('initialized'),
-		borsh.str('title'),
 		borsh.u8('rating'),
+		borsh.str('title'),
 		borsh.str('description'),
 	])
 


### PR DESCRIPTION
Fixed ordering in `borshAccountSchema` - previous ordering wasn't matching the linked final code (https://github.com/Unboxed-Software/solana-movie-frontend/blob/solution-deserialize-account-data/models/Movie.ts) and was resulting in an error:
```
RangeError: Trying to access beyond buffer length
```