### PR TITLE
On reinitialization-attacks lesson , is_initialized check is negated, should check if true instead

### DIFF
--- a/content/reinitialization-attacks.md
+++ b/content/reinitialization-attacks.md
@@ -10,13 +10,11 @@
 
 - Use an account discriminator or initialization flag to check whether an account has already been initialized to prevent an account from being reinitialized and overriding existing account data.
 - To prevent account reinitialization in plain Rust, initialize accounts with an `is_initialized` flag and check if it has already been set to true when initializing an account
-    
-    ```rust
-    if !account.is_initialized {
-        return Err(ProgramError::AccountAlreadyInitialized.into());
-    }
-    ```
-    
+  ```rust
+  if account.is_initialized {
+      return Err(ProgramError::AccountAlreadyInitialized.into());
+  }
+  ```
 - To simplify this, use Anchor’s `init` constraint to create an account via a CPI to the system program and sets its discriminator
 
 # Overview
@@ -68,7 +66,7 @@ pub struct User {
 One approach to fix this is to add an additional `is_initialized` field to the `User` account type and use it as a flag to check if an account has already been initialized.
 
 ```jsx
-if !user.is_initialized {
+if user.is_initialized {
     return Err(ProgramError::AccountAlreadyInitialized.into());
 }
 ```
@@ -87,7 +85,7 @@ pub mod initialization_secure {
 
     pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
         let mut user = User::try_from_slice(&ctx.accounts.user.data.borrow()).unwrap();
-        if !user.is_initialized {
+        if user.is_initialized {
             return Err(ProgramError::AccountAlreadyInitialized.into());
         }
 


### PR DESCRIPTION

On pure rust examples, is_initialized flag is set to true when account data is initialized therefore error should be raised when true, not when false.

Changed this in 3 parts where it appeared.