### PR TITLE
fix: wallet standard, PDAs aren't public keys, minor copy edits

### DIFF
--- a/content/anchor-cpi.md
+++ b/content/anchor-cpi.md
@@ -26,7 +26,7 @@ As a refresher, CPIs allow programs to invoke instructions on other programs usi
 
 While making CPIs directly using `invoke` or `invoke_signed` is still an option, Anchor also provides a simplified way to make CPIs by using a `CpiContext`.
 
-In this lesson, you'll use the `anchor_spl` crate to make CPIs to the SPL Token Program. You can explore what's available in the `anchor_spl` crate [here](https://docs.rs/anchor-spl/latest/anchor_spl/#).
+In this lesson, you'll use the `anchor_spl` crate to make CPIs to the SPL Token Program. You can [explore what's available in the `anchor_spl` crate](https://docs.rs/anchor-spl/latest/anchor_spl/#).
 
 ### `CpiContext`
 
@@ -275,7 +275,7 @@ In this demo we’ll update the program to mint tokens to users when they submit
 
 ### 1. Starter
 
-To get started, we will be using the final state of the Anchor Movie Review program from the previous lesson. So, if you just completed that lesson then you’re all set and ready to go. If you are just jumping in here, no worries, you can download the starter code [here](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas). We'll be using the `solution-pdas` branch as our starting point.
+To get started, we will be using the final state of the Anchor Movie Review program from the previous lesson. So, if you just completed that lesson then you’re all set and ready to go. If you are just jumping in here, no worries, you can [download the starter code](https://github.com/Unboxed-Software/anchor-movie-review-program/tree/solution-pdas). We'll be using the `solution-pdas` branch as our starting point.
 
 ### 2. Add dependencies to `Cargo.toml`
 

--- a/content/arbitrary-cpi.md
+++ b/content/arbitrary-cpi.md
@@ -237,7 +237,7 @@ it("Insecure instructions allow attacker to win every time", async () => {
 })
 ```
 
-This test effectively walks through the scenario where a regular player and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes.
+This test walks through the scenario where a regular player and an attacker both create their characters. Only the attacker passes in the program ID of the fake metadata program rather than the actual metadata program. And since the `create_character_insecure` instruction has no program checks, it still executes.
 
 The result is that the regular character has the appropriate amount of health and power: each a value between 0 and 20. But the attacker's health and power are each 255, making the attacker unbeatable.
 

--- a/content/cpi.md
+++ b/content/cpi.md
@@ -158,7 +158,7 @@ There's no need to include a signature because the Solana runtime passes along t
 ### CPI with `invoke_signed`
 
 
-Using `invoke_signed` is a little different just because there is an additional field that requires the seeds used to derive any PDAs that must sign the transaction. You may recall from previous lessons that PDAs do not lie on the Ed25519 curve and, therefore, do not have a corresponding private key. You’ve been told that programs can provide signatures for their PDAs, but have not learned how that actually happens - until now. Programs provide signatures for their PDAs with the `invoke_signed` function. The first two fields of `invoke_signed` are the same as `invoke`, but there is an additional `signers_seeds` field that comes into play here.
+Using `invoke_signed` is a little different just because there is an additional field that requires the seeds used to derive any PDAs that must sign the transaction. You may recall from previous lessons that PDAs do not lie on the Ed25519 curve and, therefore, do not have a corresponding secret key. You’ve been told that programs can provide signatures for their PDAs, but have not learned how that actually happens - until now. Programs provide signatures for their PDAs with the `invoke_signed` function. The first two fields of `invoke_signed` are the same as `invoke`, but there is an additional `signers_seeds` field that comes into play here.
 
 
 ```rust
@@ -171,7 +171,7 @@ invoke_signed(
 )?;
 ```
 
-While PDAs have no private keys of their own, they can be used by a program to issue an instruction that includes the PDA as a signer. The only way for the runtime to verify that the PDA belongs to the calling program is for the calling program to supply the seeds used to generate the address in the `signers_seeds` field.
+While PDAs have no secret keys of their own, they can be used by a program to issue an instruction that includes the PDA as a signer. The only way for the runtime to verify that the PDA belongs to the calling program is for the calling program to supply the seeds used to generate the address in the `signers_seeds` field.
 
 The Solana runtime will internally call [`create_program_address`](https://docs.rs/solana-program/1.4.4/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) using the seeds provided and the `program_id` of the calling program. It can then compare the result against the addresses supplied in the instruction. If any of the addresses match, then the runtime knows that indeed the program associated with this address is the caller and thus is authorized to be a signer.
 
@@ -193,7 +193,7 @@ EF1M4SPfKcchb6scq297y8FPCaLvj5kGjwMzjTM68wjA's signer privilege escalated
 Program returned error: "Cross-program invocation with unauthorized signer or writable account"
 ```
 
-This message is a little misleading, because “signer privilege escalated” does not seem like a problem but, in reality, it means that you are incorrectly signing for the address in the message. If you are using `invoke_signed` and receive this error, then it likely means that the seeds you are providing are incorrect. An example transaction that failed with this error can be found [here](https://explorer.solana.com/tx/3mxbShkerH9ZV1rMmvDfaAhLhJJqrmMjcsWzanjkARjBQurhf4dounrDCUkGunH1p9M4jEwef9parueyHVw6r2Et?cluster=devnet).
+This message is a little misleading, because “signer privilege escalated” does not seem like a problem but, in reality, it means that you are incorrectly signing for the address in the message. If you are using `invoke_signed` and receive this error, then it likely means that the seeds you are providing are incorrect. You can also find [an example transaction that failed with this error](https://explorer.solana.com/tx/3mxbShkerH9ZV1rMmvDfaAhLhJJqrmMjcsWzanjkARjBQurhf4dounrDCUkGunH1p9M4jEwef9parueyHVw6r2Et?cluster=devnet).
 
 Another similar error is thrown when an account that's written to isn't marked as `writable` inside the `AccountMeta` struct.
 
@@ -617,4 +617,4 @@ To apply what you've learned about CPIs in this lesson, think about how you coul
 
 A great example would be to build a decentralized Stack Overflow. The program could use tokens to determine a user's overall rating, mint tokens when questions are answered correctly, allow users to upvote answers, etc. All of that is possible and you now have the skills and knowledge to go and build something like it on your own!
 
-Congratulations on reaching the end of Module 4! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%204), so that we can continue to improve the course.
+Congratulations on reaching the end of Module 4! Feel free to [share some quick feedback](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%204), so that we can continue to improve the course.

--- a/content/deserialize-custom-data.md
+++ b/content/deserialize-custom-data.md
@@ -9,7 +9,7 @@ objectives:
 
 # TL;DR
 
-- **Program Derived Addresses**, or PDAs, are addresses that do not have a corresponding private key. The concept of PDAs allows for programs to sign for transactions themselves and allows for storing and locating data.
+- **Program Derived Addresses**, or PDAs, are addresses that do not have a corresponding secret key. The concept of PDAs allows for programs to sign for transactions themselves and allows for storing and locating data.
 - You can derive a PDA using the `findProgramAddress(seeds, programid)` method.
 - You can get an array of all the accounts belonging to a program using `getProgramAccounts(programId)`.
 - Account data needs to be deserialized using the same layout used to store it in the first place. You can use `@project-serum/borsh` to create a schema.
@@ -26,7 +26,7 @@ Programs themselves, however, are stateless. They cannot modify the data within 
 
 ### PDA
 
-PDA stands for Program Derived Address. As the name suggests, it refers to an address (public key) derived from a program and some seeds. In a previous lesson, we discussed public/private keys and how they are used on Solana. Unlike a keypair, a PDA *does not* have a corresponding private key. The purpose of a PDA is to create an address that a program can sign for in the same way a user may sign for a transaction with their wallet.
+PDA stands for Program Derived Address. As the name suggests, it refers to an address derived from a program and some seeds. In a previous lesson, we discussed public/secret keys and how they are used on Solana. Unlike a keypair, a PDA *is not* a public key and *does not* have a corresponding secret key. The purpose of a PDA is to create an address that a program can sign for in the same way a user may sign for a transaction with their wallet.
 
 When you submit a transaction to a program and expect the program to then update state or store data in some way, that program is using one or more PDAs. This is important to understand when developing client-side for two reasons:
 
@@ -37,7 +37,7 @@ When you submit a transaction to a program and expect the program to then update
 
 PDAs are not technically created. Rather, they are *found* or *derived* based on one or more input seeds.
 
-Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic function ensures that every point along the curve has a corresponding point somewhere else on the curve, allowing for public/private keys. PDAs are addresses that lie *off* the ed2559 Elliptic curve and therefore cannot be signed for by a private key (since there isn’t one). This ensures that the program is the only valid signer for that address.
+Regular Solana keypairs lie on the ed2559 Elliptic Curve. This cryptographic function ensures that every point along the curve has a corresponding point somewhere else on the curve, allowing for public/secret keys. PDAs are addresses that lie *off* the ed2559 Elliptic curve and therefore cannot be signed for by a secret key (since there isn’t one). This ensures that the program is the only valid signer for that address.
 
 To find a public key that does not lie on the ed2559 curve, the program ID and seeds of the developer’s choice (like a string of text) are passed through the function [`findProgramAddress(seeds, programid)`](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html#findProgramAddress). This function combines the program ID, seeds, and a bump seed into a buffer and passes it into a SHA256 hash to see whether or not the resulting address is on the curve. If the address is on the curve (~50% chance it is), then the bump seed is decremented by 1 and the address is calculated again. The bump seed starts at 255 and progressively iterates down to `bump = 254`, `bump = 253`, etc. until an address is found with the given seeds and bump that does not lie on the ed2559 curve. The `findProgramAddress` function returns the resulting address and the bump used to kick it off the curve. This way, the address can be generated anywhere as long as you have the bump and seeds.
 
@@ -258,7 +258,7 @@ Now it’s your turn to build something independently. Last lesson, you worked o
 
 ![Screenshot of Student Intros frontend](../assets/student-intros-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
+1. You can build this from scratch or you can [download the starter code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
 2. Create the account buffer layout in `StudentIntro.ts`. The account data contains:
    1. `initialized` as an unsigned, 8-bit integer representing the instruction to run (should be 1).
    2. `name` as a string representing the student's name.
@@ -267,6 +267,6 @@ Now it’s your turn to build something independently. Last lesson, you worked o
 4. In the `StudentIntroList` component's `useEffect`, get the program's accounts and deserialize their data into a list of `StudentIntro` objects.
 5. Instead of mock data, you should now be seeing student introductions from the network!
 
-If you get really stumped, feel free to check out the solution code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data).
+If you get really stumped, feel free to [check out the solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-deserialize-account-data).
 
 As always, get creative with these challenges and take them beyond the instructions if you want!

--- a/content/es/rust-macros.md
+++ b/content/es/rust-macros.md
@@ -518,7 +518,7 @@ impl Config {
 
 The `programs/admin/src/lib.rs` file contains the program entrypoint with the definitions of the program's instructions. Currently, the program has instructions to initialize this account and then one instruction per account field for updating the field.
 
-The `programs/admin/src/admin_config` directory contains the program's instruction logic and state. Take a look through each of these files. You'll notice that instruction logic for each field is effectively duplicated for each instruction.
+The `programs/admin/src/admin_config` directory contains the program's instruction logic and state. Take a look through each of these files. You'll notice that instruction logic for each field is duplicated for each instruction.
 
 The goal of this demo is to implement a procedural macro that will allow us to replace all of the instruction logic functions and automatically generate functions for each instruction.
 

--- a/content/hello-world-program.md
+++ b/content/hello-world-program.md
@@ -127,7 +127,7 @@ Recall that all data stored on the Solana network are contained in what are refe
 
 ### Solana Program Crate
 
-To write Solana programs with Rust, we use the `solana_program` library crate. The `solana_program` crate acts as a standard library for Solana programs. This standard library contains the modules and macros that we'll use to develop our Solana programs. If you want to dig deeper `solana_program` crate, have a look [here](https://docs.rs/solana-program/latest/solana_program/index.html).
+To write Solana programs with Rust, we use the `solana_program` library crate. The `solana_program` crate acts as a standard library for Solana programs. This standard library contains the modules and macros that we'll use to develop our Solana programs. If you want to dig deeper into the `solana_program` crate, have a look [at the `solana_program` crate documentation](https://docs.rs/solana-program/latest/solana_program/index.html).
 
 For a basic program we will need to bring into scope the following items from the `solana_program` crate:
 
@@ -171,7 +171,7 @@ Recall that Solana program accounts only store the logic to process instructions
 
 In order to process an instruction, the data accounts that an instruction requires must be explicitly passed into the program through the `accounts` argument. Any additional inputs must be passed in through the `instruction_data` argument.
 
-Following program execution, the program must return a value of type `ProgramResult`. This type is a `Result` where the embedded value of a success case is `()` and the embedded value of a failure case is `ProgramError`. `()` is effectively an empty value and `ProgramError` is an error type defined in the `solana_program` crate.
+Following program execution, the program must return a value of type `ProgramResult`. This type is a `Result` where the embedded value of a success case is `()` and the embedded value of a failure case is `ProgramError`. `()` is an empty value and `ProgramError` is an error type defined in the `solana_program` crate.
 
 ...and there you have it - you now know all the things you need for the foundations of creating a Solana program using Rust. Let’s practice what we’ve learned so far!
 
@@ -181,7 +181,7 @@ We're going to build a "Hello, World!" program using Solana Playground. Solana P
 
 ### 1. Setup
 
-Click [here](https://beta.solpg.io/) to open Solana Playground. Next, go ahead and delete everything in the default `lib.rs` file and create a Playground wallet.
+Open the [Solana Playground](https://beta.solpg.io/). Next, go ahead and delete everything in the default `lib.rs` file and create a Playground wallet.
 
 ![Gif Solana Playground Create Wallet](../assets/hello-world-create-wallet.gif)
 
@@ -249,9 +249,9 @@ Now let's build and deploy our program using Solana Playground.
 
 ### 5. Invoke Program
 
-Finally, let's invoke our program from the client side. Download the code [here](https://github.com/Unboxed-Software/solana-hello-world-client).
+Finally, let's invoke our program from the client side. The focus of this lesson is to build our Solana program, so we’ve gone ahead and provided [the client code to invoke our “Hello, world!” program](https://github.com/Unboxed-Software/solana-hello-world-client) for you to download.
 
-The focus of this lesson is to build our Solana program, so we’ve gone ahead and provided the client code to invoke our “Hello, world!” program. The code provided includes a `sayHello` helper function that builds and submits our transaction. We then call `sayHello` in the main function and print a Solana Explorer URL to view our transaction details in the browser.
+The code provided includes a `sayHello` helper function that builds and submits our transaction. We then call `sayHello` in the main function and print a Solana Explorer URL to view our transaction details in the browser.
 
 Open the `index.ts` file you should see a variable named `programId`. Go ahead and update this with the program ID of the “Hello, world!" program you just deployed using Solana Playground.
 

--- a/content/interact-with-wallets.md
+++ b/content/interact-with-wallets.md
@@ -51,12 +51,13 @@ Finally, there are packages that are adapters for specific wallets, including Ph
 
 ### Install Wallet-Adapter Libraries
 
-When adding wallet support to an existing react app, you start by installing the appropriate packages. You’ll need `@solana/wallet-adapter-base`, `@solana/wallet-adapter-react`, the package(s) for the wallet(s) you want to support, and `@solana/wallet-adapter-react-ui` if you plan to use the provided react components, e.g.
+When adding wallet support to an existing react app, you start by installing the appropriate packages. You’ll need `@solana/wallet-adapter-base`, `@solana/wallet-adapter-react`. If you plan to use the provided react components, you'll also need to add `@solana/wallet-adapter-react-ui`.
+
+All wallets that support [wallet standard](https://github.com/wallet-standard/wallet-standard) are supported out of the box, and nearly all current Solana wallets support wallet standard. However if you wish to add support for any wallets that don't support the standard, add a package for them.
 
 ```
 npm install @solana/wallet-adapter-base \
     @solana/wallet-adapter-react \
-    @solana/wallet-adapter-phantom \
     @solana/wallet-adapter-react-ui
 ```
 
@@ -94,7 +95,7 @@ export const Home: NextPage = (props) => {
 
 Note that `ConnectionProvider` requires an `endpoint` property and that `WalletProvider` requires a `wallets` property. We’re continuing to use the endpoint for the Devnet cluster, and for now we’re only using the `PhantomWalletAdapter` for `wallets`.
 
-At this point you can connect with `wallet.connect()`, which will effectively instruct the wallet to prompt the user for permission to view their public key and request approval for transactions.
+At this point you can connect with `wallet.connect()`, which will instruct the wallet to prompt the user for permission to view their public key and request approval for transactions.
 
 ![Screenshot of wallet connection prompt](../assets/wallet-connect-prompt.png)
 
@@ -224,7 +225,7 @@ Once you have a wallet, click the settings gear on the bottom right in the Phant
 
 ### 2. Download the starter code
 
-Download the starter code for this project [here](https://github.com/Unboxed-Software/solana-ping-frontend/tree/starter). This project is a simple Next.js application. It’s mostly empty except for the `AppBar` component. We’ll build the rest throughout this demo.
+Download the [starter code for this project](https://github.com/Unboxed-Software/solana-ping-frontend/tree/starter). This project is a simple Next.js application. It’s mostly empty except for the `AppBar` component. We’ll build the rest throughout this demo.
 
 You can see its current state with the command `npm run dev` in the console.
 
@@ -459,7 +460,7 @@ And that’s it! If you refresh the page, connect your wallet, and click the pin
 
 There’s a lot you could do to make the user experience here even better. For example, you could change the UI to only show you the Ping button when a wallet is connected and display some other prompt otherwise. You could link to the transaction on Solana Explorer after a user confirms a transaction so they can easily go look at the transaction details. The more you experiment with it, the more comfortable you’ll get, so get creative!
 
-If you need to spend some time looking at the full source code from this demo to understand all of this in context, check that out [here](https://github.com/Unboxed-Software/solana-ping-frontend).
+You can also download the [full source code from this demo](https://github.com/Unboxed-Software/solana-ping-frontend) to understand all of this in context.
 
 # Challenge
 
@@ -467,9 +468,9 @@ Now it’s your turn to build something independently. Create an application tha
 
 ![Screenshot of Send Sol App](../assets/solana-send-sol-app.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/starter).
+1. You can build this from scratch or you can [download the starter code](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/starter).
 2. Wrap the starter application in the appropriate context providers.
 3. In the form component, set up the transaction and send it to the user’s wallet for approval.
 4. Get creative with the user experience. Add a link to let the user view the transaction on Solana Explorer or something else that seems cool to you!
 
-If you get really stumped, feel free to check out the solution code [here](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/main).
+If you get really stumped, feel free to [check out the solution code](https://github.com/Unboxed-Software/solana-send-sol-frontend/tree/main).

--- a/content/intro-to-anchor-frontend.md
+++ b/content/intro-to-anchor-frontend.md
@@ -207,7 +207,7 @@ Once you have the IDL and a provider, you can create an instance of `Program`. T
 - `programId` - the on-chain address of the program as a `string` or `PublicKey`
 - `Provider` - the provider discussed in the previous section
 
-The `Program` object creates a custom API you can use to interact with a Solana program. This API is the one stop shop for all things related to communicating with on-chain programs. Among other things, you can send transactions, fetch deserialized accounts, decode instruction data, subscribe to account changes, and listen to events. You can learn more about the `Program` class [here](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
+The `Program` object creates a custom API you can use to interact with a Solana program. This API is the one stop shop for all things related to communicating with on-chain programs. Among other things, you can send transactions, fetch deserialized accounts, decode instruction data, subscribe to account changes, and listen to events. You can also [learn more about the `Program` class](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
 To create the `Program` object, first import `Program` and `Idl` from `@project-serum/anchor`. `Idl` is a type you can used when working with Typescript.
 
@@ -344,7 +344,7 @@ Let’s practice this together by building a frontend for the Counter program fr
 
 ### 1. Download the starter code
 
-Download the starter code for this project [here](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/starter). Once you have the starter code, take a look around. Install the dependencies with `npm install` and then run the app with `npm run dev`.
+Download [the starter code for this project](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/starter). Once you have the starter code, take a look around. Install the dependencies with `npm install` and then run the app with `npm run dev`.
 
 This project is a simple Next.js application. It includes the `WalletContextProvider` we created in the [Wallets lesson](https://github.com/Unboxed-Software/solana-course/blob/main/content/interact-with-wallets.md), the `idl.json` file for the Counter program, and the `Initialize` and `Increment` components we’ll be building throughout this demo. The `programId` of the program we’ll be invoking is also included in the starter code.
 
@@ -508,6 +508,6 @@ Before building the component in the frontend, you’ll first need to:
 2. Update the IDL file in the frontend with the one from your new program
 3. Update the `programId` with the one from your new program
 
-If you need some help, feel free to reference this program [here](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).
+If you need some help, feel free to [reference this program](https://github.com/Unboxed-Software/anchor-counter-program/tree/solution-decrement).
 
 Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/anchor-ping-frontend/tree/solution-decrement).

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -235,7 +235,7 @@ The `#[account]` attribute is applied to structs representing the data structure
 - `Discriminator`
 - `Owner`
 
-You can read more about the details of each trait [here](https://docs.rs/anchor-lang/latest/anchor_lang/attr.account.html). However, mostly what you need to know is that the `#[account]` attribute enables serialization and deserialization, and implements the discriminator and owner traits for an account.
+You can read more about the [details of each trait](https://docs.rs/anchor-lang/latest/anchor_lang/attr.account.html). However, mostly what you need to know is that the `#[account]` attribute enables serialization and deserialization, and implements the discriminator and owner traits for an account.
 
 The discriminator is an 8 byte unique identifier for an account type derived from the first 8 bytes of the SHA256 hash of the account type's name. When implementing account serialization traits, the first 8 bytes are reserved for the account discriminator.
 
@@ -313,7 +313,7 @@ You are now ready to build your own Solana program using the Anchor framework!
 
 # Demo
 
-Before we begin, install Anchor by following the steps [here](https://www.anchor-lang.com/docs/installation).
+Before we begin, install Anchor by [following the steps from the Anchor docs](https://www.anchor-lang.com/docs/installation).
 
 For this demo we'll create a simple counter program with two instructions:
 

--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -46,17 +46,17 @@ If you are on Windows 10 version 2004 and higher (Build 19041 and higher) or Win
 wsl --install
 ```
 
-If you are running an older version of Windows, follow the instructions [here](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
+If you are running an older version of Windows, follow [the instructions for older versions of Windows](https://docs.microsoft.com/en-us/windows/wsl/install-manual).
 
-You can read more about installing WSL [here](https://docs.microsoft.com/en-us/windows/wsl/install).
+You can [read more about installing WSL from Microsoft](https://docs.microsoft.com/en-us/windows/wsl/install).
 
 ### Download Ubuntu
 
-Next, download Ubuntu [here](https://apps.microsoft.com/store/detail/ubuntu-2004/9N6SVWS3RX71?hl=en-us&gl=US). Ubuntu provides a terminal that allows you to run Linux on a Windows computer. This is where you’ll be running Solana CLI commands.
+Next, [download Ubuntu](https://apps.microsoft.com/store/detail/ubuntu-2004/9N6SVWS3RX71?hl=en-us&gl=US). Ubuntu provides a terminal that allows you to run Linux on a Windows computer. This is where you’ll be running Solana CLI commands.
 
 ### Download Rust (for WSL)
 
-Next, open an Ubuntu terminal and download Rust for WSL using the following command. You can read more about downloading Rust [here](https://www.rust-lang.org/learn/get-started).
+Next, open an Ubuntu terminal and download Rust for WSL using the following command. You can read more about [downloading Rust from the docs](https://www.rust-lang.org/learn/get-started).
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -64,7 +64,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Download Solana CLI
 
-Now we are ready to download Solana CLI for Linux. Go ahead and run the following command in an Ubuntu terminal. You can read more about downloading Solana CLI [here](https://docs.solana.com/cli/install-solana-cli-tools).
+Now we are ready to download Solana CLI for Linux. Go ahead and run the following command in an Ubuntu terminal. You can read more about [downloading Solana CLI from the docs](https://docs.solana.com/cli/install-solana-cli-tools).
 
 ```bash
 sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
@@ -74,7 +74,7 @@ sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
 
 ### Download Rust
 
-First, download Rust by following the instructions [here](https://www.rust-lang.org/tools/install)
+First, download Rust by [following the instructions](https://www.rust-lang.org/tools/install)
 
 ### Download the Solana CLI
 
@@ -84,7 +84,7 @@ Next, download the Solana CLI by running the following command in your terminal.
 sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
 ```
 
-You can read more about downloading the Solana CLI [here](https://docs.solana.com/cli/install-solana-cli-tools).
+You can read more about [downloading the Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools).
 
 ## Solana CLI basics
 
@@ -332,7 +332,7 @@ Before we invoke our program, open a separate terminal and run the `solana logs`
 solana logs <PROGRAM_ID>
 ```
 
-With the test validator still running, try invoking your program using the client-side script [here](https://github.com/Unboxed-Software/solana-hello-world-client).
+With the test validator still running, try invoking your program using [this client-side script](https://github.com/Unboxed-Software/solana-hello-world-client).
 
 Replace the program ID in `index.ts` with the one from the program you just deployed, then run `npm install` followed by `npm start`. This will return a Solana Explorer URL. Copy the URL into the browser to look up the transaction on Solana Explorer and check that “Hello, world!” was printed to the program log. Alternatively, you can view the program logs in the terminal where you ran the `solana logs` command.
 

--- a/content/nfts-with-metaplex.md
+++ b/content/nfts-with-metaplex.md
@@ -206,7 +206,7 @@ When creating and distributing a bulk supply of NFT's, Metaplex makes it easy wi
 
 Candy Machine is effectively a minting and distribution program to help launch NFT collections. Sugar is a command line interface that helps you create a candy machine, prepare assets, and create NFTs at scale. The steps covered above for creating an NFT would be incredibly tedious to execute for thousands of NFTs in one go. Candy Machine and Sugar solve this and help ensure a fair launch by offering a number of safeguards.
 
-We won't cover these tools in-depth, but definitely check out how they work together [here](https://docs.metaplex.com/developer-tools/sugar/overview/introduction).
+We won't cover these tools in-depth, but definitely check out [how Candy Machine and Sugar work together from the Metaplex docs](https://docs.metaplex.com/developer-tools/sugar/overview/introduction).
 
 To explore the full range of tools offered by Metaplex, you can view the [Metaplex repository](https://github.com/metaplex-foundation/metaplex) on GitHub. 
 
@@ -577,4 +577,4 @@ To deepen your understanding of the Metaplex tools, dive into the Metaplex docum
 
 Once you have an understanding of how the the Candy Machine program works, put your knowledge to the test by using the Sugar CLI to create a Candy Machine for your own collection. This hands-on experience will not only reinforce your understanding of the tools, but also boost your confidence in your ability to use them effectively in the future.
 
-Have some fun with this! This will be your first independently created NFT collection! With this, you'll complete Module 2. Hope you're feeling the process! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%202) so that we can continue to improve the course!
+Have some fun with this! This will be your first independently created NFT collection! With this, you'll complete Module 2. Hope you're feeling the process! Feel free to [share some quick feedback](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%202) so that we can continue to improve the course!

--- a/content/owner-checks.md
+++ b/content/owner-checks.md
@@ -56,7 +56,7 @@ The example below shows an `admin_instruction` intended to be accessible only by
 
 Although the instruction checks the `admin` account signed the transaction and matches the `admin` field stored on the `admin_config` account, there is no owner check to verify the `admin_config` account passed into the instruction is owned by the executing program.
 
-Since the `admin_config` is unchecked as indicated by the `AccountInfo` type, a fake `admin_config` account owned by a different program could be used in the `admin_instruction`. This means that an attacker could create a program with an `admin_config` whose data structure matches the `admin_config` of your program, set their public key as the `admin` and pass their `admin_config` account into your program. This would let them effectively spoof your program into thinking that they are the authorized admin for your program.
+Since the `admin_config` is unchecked as indicated by the `AccountInfo` type, a fake `admin_config` account owned by a different program could be used in the `admin_instruction`. This means that an attacker could create a program with an `admin_config` whose data structure matches the `admin_config` of your program, set their public key as the `admin` and pass their `admin_config` account into your program. This would let them spoof your program into thinking that they are the authorized admin for your program.
 
 This simplified example only prints the `admin` to the program logs. However, you can imagine how a missing owner check could allow fake accounts to exploit an instruction.
 

--- a/content/paging-ordering-filtering-data.md
+++ b/content/paging-ordering-filtering-data.md
@@ -434,6 +434,6 @@ Now it’s your turn to try and do this on your own. Using the Student Intros ap
 3. Order the accounts displayed in the app alphabetically by name.
 4. Add the ability to search through introductions by a student’s name.
 
-This is challenging. If you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-paging-account-data). With this you complete Module 1! How was your experience? Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%201), so that we can continue to improve the course!
+This is challenging. If you get stuck, feel free to reference the [solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-paging-account-data). With this you complete Module 1! How was your experience? Feel free to [share some quick feedback](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%201), so that we can continue to improve the course!
 
 As always, get creative with these challenges and take them beyond the instructions if you want! 

--- a/content/pda-sharing.md
+++ b/content/pda-sharing.md
@@ -210,7 +210,7 @@ After that, there are two more tests to show how the instructions are vulnerable
 
 The first test invokes the `initialize_pool` instruction to create a "fake" `pool` account using the same `vault` token account, but a different `withdraw_destination`.
 
-The second test withdraws from this pool, effectively stealing funds from the vault.
+The second test withdraws from this pool, stealing funds from the vault.
 
 ```tsx
 it("Insecure initialize allows pool to be initialized with wrong vault", async () => {

--- a/content/pda.md
+++ b/content/pda.md
@@ -25,7 +25,7 @@ Program Derived Addresses (PDAs) are account addresses designed to be signed for
 PDAs serve two main functions:
 
 1. Provide a deterministic way to find the address of a program-owned account
-2. Authorize the program from which a PDA was derived to sign on its behalf in the same way a user may sign with their private key
+2. Authorize the program from which a PDA was derived to sign on its behalf in the same way a user may sign with their secret key
 
 In this lesson we'll focus on using PDAs to find and store data. We'll discuss signing with a PDA more thoroughly in a future lesson where we cover Cross Program Invocations (CPIs).
 
@@ -33,9 +33,9 @@ In this lesson we'll focus on using PDAs to find and store data. We'll discuss s
 
 PDAs are not technically created. Rather, they are *found* or *derived* based on a program ID and one or more input seeds.
 
-Solana keypairs can be found on what is called the Ed25519 Elliptic Curve (Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to generate corresponding public and private keys. Together, we call these keypairs.
+Solana keypairs can be found on what is called the Ed25519 Elliptic Curve (Ed25519). Ed25519 is a deterministic signature scheme that Solana uses to generate corresponding public and secret keys. Together, we call these keypairs.
 
-Alternatively, PDAs are addresses that lie *off* the Ed25519 curve. This effectively means they are public keys *without* a corresponding private key. This property of PDAs is essential for programs to be able to sign on their behalf, but we'll cover that in a future lesson.
+Alternatively, PDAs are addresses that lie *off* the Ed25519 curve. This means PDAs are not public keys, and don't have private keys. This property of PDAs is essential for programs to be able to sign on their behalf, but we'll cover that in a future lesson.
 
 To find a PDA within a Solana program, we'll use the `find_program_address` function. This function takes an optional list of “seeds” and a program ID as inputs, and then returns the PDA and a bump seed.
 
@@ -47,7 +47,7 @@ let (pda, bump_seed) = Pubkey::find_program_address(&[user.key.as_ref(), user_in
 
 “Seeds” are optional inputs used in the `find_program_address` function to derive a PDA. For example, seeds can be any combination of public keys, inputs provided by a user, or hardcoded values. A PDA can also be derived using only the program ID and no additional seeds. Using seeds to find our PDAs, however, allows us to create an arbitrary number of accounts that our program can own.
 
-While you, the developer, determine the seeds to pass into the `find_program_address` function, the function itself provides an additional seed called a "bump seed." The cryptographic function for deriving a PDA results in a key that lies *on* the Ed25519 curve about 50% of the time. In order to ensure that the result *is not* on the Ed25519 curve and therefore does not have a private key, the `find_program_address` function adds a numeric seed called a bump seed.
+While you, the developer, determine the seeds to pass into the `find_program_address` function, the function itself provides an additional seed called a "bump seed." The cryptographic function for deriving a PDA results in a key that lies *on* the Ed25519 curve about 50% of the time. In order to ensure that the result *is not* on the Ed25519 curve and therefore does not have a secret key, the `find_program_address` function adds a numeric seed called a bump seed.
 
 The function starts by using the value `255` as the bump seed, then checks to see if the output is a valid PDA. If the result is not a valid PDA, the function decreases the bump seed by 1 and tries again (`255`, `254`, `253`, et cetera). Once a valid PDA is found, the function returns both the PDA and the bump that was used to derive the PDA.
 
@@ -205,7 +205,7 @@ Previously, we finished implementing the ability to update a movie review in a s
 
 ### 1. Get the starter code
 
-To begin, you can find the starter code [here](https://github.com/Unboxed-Software/solana-movie-program/tree/starter) on the `starter` branch.
+To begin, you can find [the movie program starter code](https://github.com/Unboxed-Software/solana-movie-program/tree/starter) on the `starter` branch.
 
 If you've been following along with the Movie Review demos, you'll notice that this is the program we’ve built out so far. Previously, we used [Solana Playground](https://beta.solpg.io/) to write, build, and deploy our code. In this lesson, we’ll build and deploy the program locally.
 

--- a/content/program-security.md
+++ b/content/program-security.md
@@ -188,7 +188,7 @@ Just as before, we'll be using [Solana Playground](https://beta.solpg.io/) to w
 
 ## 1. Get the starter code
 
-To begin, you can find the starter code [here](https://beta.solpg.io/62b552f3f6273245aca4f5c9). If you've been following along with the Movie Review demos, you'll notice that we've refactored our program.
+To begin, you can find [the movie review starter code](https://beta.solpg.io/62b552f3f6273245aca4f5c9). If you've been following along with the Movie Review demos, you'll notice that we've refactored our program.
 
 The refactored starter code is almost the same as what it was before. Since `lib.rs` was getting rather large and unwieldy, we've separated its code into 3 files: `lib.rs`, `entrypoint.rs`, and `processor.rs`. `lib.rs` now *only* registers the code's modules, `entrypoint.rs` *only* defines and sets the program's entrypoint, and `processor.rs` handles the program logic for processing instructions. We've also added an `error.rs` file where we'll be defining custom errors. The complete file structure is as follows:
 
@@ -720,4 +720,4 @@ Using what you've learned in this lesson, try applying what you've learned to th
 1. Add an instruction allowing students to update their message
 2. Implement the basic security checks we've learned in this lesson
 
-Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62c9120df6273245aca4f5e8). Note that your code may look slightly different than the solution code depending on the checks you implement and the errors you write. Once you complete Module 3, we'd love to know more about your experience! Feel free to share some quick feedback [here](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%203), so that we can continue to improve the course.
+Try to do this independently if you can! But if you get stuck, feel free to reference the [solution code](https://beta.solpg.io/62c9120df6273245aca4f5e8). Note that your code may look slightly different than the solution code depending on the checks you implement and the errors you write. Once you complete Module 3, we'd love to know more about your experience! Feel free to [share some quick feedback](https://airtable.com/shrOsyopqYlzvmXSC?prefill_Module=Module%203), so that we can continue to improve the course.

--- a/content/program-state-management.md
+++ b/content/program-state-management.md
@@ -129,7 +129,7 @@ pub fn invoke_signed(
 ) -> ProgramResult
 ```
 
-For this lesson we will use `invoke_signed`. Unlike a regular signature where a private key is used to sign, `invoke_signed` uses the optional seeds, bump seed, and program ID to derive a PDA and sign an instruction. This is done by comparing the derived PDA against all accounts passed into the instruction. If any of the accounts match the PDA, then the signer field for that account is set to true.
+For this lesson we will use `invoke_signed`. Unlike a regular signature where a secret key is used to sign, `invoke_signed` uses the optional seeds, bump seed, and program ID to derive a PDA and sign an instruction. This is done by comparing the derived PDA against all accounts passed into the instruction. If any of the accounts match the PDA, then the signer field for that account is set to true.
 
 A program can securely sign transactions this way because `invoke_signed` generates the PDA used for signing with the program ID of the program invoking the instruction. Therefore, it is not possible for one program to generate a matching PDA to sign for an account with a PDA derived using another program ID.
 
@@ -178,7 +178,7 @@ This is done with the `serialize` function on the instance of the Rust type you 
 account_data.serialize(&mut &mut note_pda_account.data.borrow_mut()[..])?;
 ```
 
-The above example converts the `account_data` object to a byte array and sets it to the `data` property on `note_pda_account`. This effectively saves the updated `account_data` variable to the data field of the new account. Now when a user fetches the `note_pda_account` and deserializes the data, it will display the updated data we’ve serialized into the account.
+The above example converts the `account_data` object to a byte array and sets it to the `data` property on `note_pda_account`. This saves the updated `account_data` variable to the data field of the new account. Now when a user fetches the `note_pda_account` and deserializes the data, it will display the updated data we’ve serialized into the account.
 
 ## Iterators
 
@@ -211,7 +211,7 @@ At that point, instead of using the iterator directly, we pass it to the `next_a
 
 For example, the instruction to create a new note in a note-taking program would at minimum require the accounts for the user creating the note, a PDA to store the note, and the `system_program` to initialize a new account. All three accounts would be passed into the program entry point through the `accounts` argument. An iterator of `accounts` is then used to separate out the `AccountInfo` associated with each account to process the instruction.
 
-Note that `&mut` means a mutable reference to the `accounts` argument. You can read more about references in Rust [here](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html) and the `mut` keyword [here](https://doc.rust-lang.org/std/keyword.mut.html).
+Note that `&mut` means a mutable reference to the `accounts` argument. You can read more about [references in Rust](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html) and [the `mut` keyword](https://doc.rust-lang.org/std/keyword.mut.html).
 
 ```rust
 // Get Account iterator
@@ -231,7 +231,7 @@ As a refresher, we are building a Solana program which lets users review movies.
 
 ### 1. Get the starter code
 
-If you didn’t complete the demo from the last lesson or just want to make sure that you didn’t miss anything, you can reference the starter code [here](https://beta.solpg.io/6295b25b0e6ab1eb92d947f7).
+If you didn’t complete the demo from the last lesson or just want to make sure that you didn’t miss anything, you can reference [the starter code](https://beta.solpg.io/6295b25b0e6ab1eb92d947f7).
 
 Our program currently includes the `instruction.rs` file we use to deserialize the `instruction_data` passed into the program entry point. We have also completed `lib.rs` file to the point where we can print our deserialized instruction data to the program log using the `msg!` macro.
 
@@ -269,7 +269,7 @@ pub struct MovieAccountState {
 
 ### 3. Update `lib.rs`
 
-Next, let’s update our `lib.rs` file. First, we’ll bring into scope everything we will need to complete our Movie Review program. You can read more about the details each item we are using from the `solana_program` crate [here](https://docs.rs/solana-program/latest/solana_program/).
+Next, let’s update our `lib.rs` file. First, we’ll bring into scope everything we will need to complete our Movie Review program. You can read more about the details each item we are using from [the `solana_program` crate](https://docs.rs/solana-program/latest/solana_program/).
 
 ```rust
 use solana_program::{

--- a/content/rust-macros.md
+++ b/content/rust-macros.md
@@ -41,7 +41,7 @@ Examples of Rust tokens include:
 -   [Punctuation](https://doc.rust-lang.org/reference/tokens.html#punctuation) marks, such as `{`, `}`, and `;`, are used to structure and delimit blocks of code.
 -   [Literals](https://doc.rust-lang.org/reference/tokens.html#literals), such as numbers and strings, represent constant values in a Rust program.
 
-You can read more about Rust tokens [here](https://doc.rust-lang.org/reference/tokens.html).
+You can [read more about Rust tokens](https://doc.rust-lang.org/reference/tokens.html).
 
 ### Item
 
@@ -56,7 +56,7 @@ There are several different kinds of items, such as:
 -   Modules
 -   Macros
 
-You can read more about Rust items [here](https://doc.rust-lang.org/reference/items.html).
+You can [read more about Rust items](https://doc.rust-lang.org/reference/items.html).
 
 ### Token Streams
 
@@ -518,7 +518,7 @@ impl Config {
 
 The `programs/admin/src/lib.rs` file contains the program entrypoint with the definitions of the program's instructions. Currently, the program has instructions to initialize this account and then one instruction per account field for updating the field.
 
-The `programs/admin/src/admin_config` directory contains the program's instruction logic and state. Take a look through each of these files. You'll notice that instruction logic for each field is effectively duplicated for each instruction.
+The `programs/admin/src/admin_config` directory contains the program's instruction logic and state. Take a look through each of these files. You'll notice that instruction logic for each field is duplicated for each instruction.
 
 The goal of this demo is to implement a procedural macro that will allow us to replace all of the instruction logic functions and automatically generate functions for each instruction.
 

--- a/content/serialize-instruction-data.md
+++ b/content/serialize-instruction-data.md
@@ -49,9 +49,7 @@ The byte buffer lets you pass external data to a program.
 
 You can include multiple instructions in a single transaction. The Solana runtime will process these instructions in order and atomically. In other words, if every instruction succeeds then the transaction as a whole will be successful, but if a single instruction fails then the entire transaction will fail immediately with no side-effects.
 
-A note on the account array and optimization:
-
-It is not just an array of the accounts’ public keys. Each object in the array includes the account’s public key, whether or not it is a signer on the transaction, and whether or not it is writable. Including whether or not an account is writable during the execution of an instruction allows the runtime to facilitate parallel processing of smart contracts. Because you must define which accounts are read-only and which you will write to, the runtime can determine which transactions are non-overlapping or read-only and allow them to execute concurrently. To learn more about the Solana’s runtime, check out this [blog post](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts).
+The account array is not just an array of the accounts’ public keys. Each object in the array includes the account’s public key, whether or not it is a signer on the transaction, and whether or not it is writable. Including whether or not an account is writable during the execution of an instruction allows the runtime to facilitate parallel processing of smart contracts. Because you must define which accounts are read-only and which you will write to, the runtime can determine which transactions are non-overlapping or read-only and allow them to execute concurrently. To learn more about the Solana’s runtime, check out this [blog post](https://solana.com/news/sealevel---parallel-processing-thousands-of-smart-contracts).
 
 ### Instruction Data
 
@@ -99,7 +97,7 @@ const equipPlayerSchema = borsh.struct([
 ])
 ```
 
-You can then encode data using this schema with the `encode` method. This method accepts as arguments an object representing the data to be serialized and a buffer. In the below example, we allocate a new buffer that’s much larger than needed, then encode the data into that buffer and slice it down into a new buffer that’s only as large as needed.
+You can then encode data using this schema with the `encode` method. This method accepts as arguments an object representing the data to be serialized and a buffer. In the below example, we allocate a new buffer that’s much larger than needed, then encode the data into that buffer and slice the original buffer down into a new buffer that’s only as large as needed.
 
 ```tsx
 import * as borsh from '@project-serum/borsh'
@@ -392,7 +390,7 @@ Now it’s your turn to build something independently. Create an application tha
 
 ![Screenshot of Student Intros frontend](../assets/student-intros-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/starter).
+1. You can build this from scratch or you can [download the starter code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/starter).
 2. Create the instruction buffer layout in `StudentIntro.ts`. The program expects instruction data to contain:
    1. `variant` as an unsigned, 8-bit integer representing the instruction to run (should be 0).
    2. `name` as a string representing the student's name.
@@ -401,6 +399,6 @@ Now it’s your turn to build something independently. Create an application tha
 4. In the `Form` component, implement the `handleTransactionSubmit` function so that it serializes a `StudentIntro`, builds the appropriate transaction and transaction instructions, and submits the transaction to the user's wallet.
 5. You should now be able to submit introductions and have the information stored on chain! Be sure to log the transaction ID and look at it in Solana Explorer to verify that it worked.
 
-If you get really stumped, you can check out the solution code [here](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
+If you get really stumped, you can [check out the solution code](https://github.com/Unboxed-Software/solana-student-intros-frontend/tree/solution-serialize-instruction-data).
 
 Feel free to get creative with these challenges and take them even further. The instructions aren't here to hold you back!

--- a/content/solana-pay.md
+++ b/content/solana-pay.md
@@ -333,7 +333,7 @@ If you were able to successfully execute the transaction using the QR code, you'
 
 Now that you're up and running, it's time to create an endpoint that supports transaction requests for location check-in using the Scavenger Hunt program.
 
-Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper function for initializing `eventOrganizer` from a private key environment variable.  The first thing we'll do in this file is the following:
+Start by opening the file at `pages/api/checkIn.ts`. Notice that it has a helper function for initializing `eventOrganizer` from a secret key environment variable.  The first thing we'll do in this file is the following:
 
 1. Export a `handler` function to handle an arbitrary HTTP request
 2. Add `get` and `post` functions for handling those HTTP methods

--- a/content/token-program.md
+++ b/content/token-program.md
@@ -493,7 +493,7 @@ We’re going to create a script that interacts with instructions on the Token P
 
 Let’s start with some basic scaffolding. You’re welcome to set up your project however feels most appropriate for you, but we’ll be using a simple Typescript project with a dependency on the `@solana/web3.js` and `@solana/spl-token` packages.
 
-You can use `npx create-solana-client [INSERT_NAME_HERE] --initialize-keypair` in the command line to clone the template we'll be starting from. Or you can manually clone the template [here](https://github.com/Unboxed-Software/solana-npx-client-template/tree/with-keypair-env). Note if you use the git repository directly as your starting point that we'll be starting from the `with-keypair-env` branch.
+You can use `npx create-solana-client [INSERT_NAME_HERE] --initialize-keypair` in the command line to clone the template we'll be starting from. Or you can [manually clone the template](https://github.com/Unboxed-Software/solana-npx-client-template/tree/with-keypair-env). Note if you use the git repository directly as your starting point that we'll be starting from the `with-keypair-env` branch.
 
 You'll then need to add a dependency on `@solana/spl-token`. From the command line inside the newly created directory, use the command `npm install @solana/spl-token`.
 
@@ -1064,7 +1064,7 @@ Note that you will not be able to directly use the helper functions we went over
 
 ![Screenshot of Token Program Challenge Frontend](../assets/token-program-frontend.png)
 
-1. You can build this from scratch or you can download the starter code [here](https://github.com/Unboxed-Software/solana-token-frontend/tree/starter).
+1. You can build this from scratch or you can [download the starter code](https://github.com/Unboxed-Software/solana-token-frontend/tree/starter).
 2. Create a new Token Mint in the `CreateMint` component.
     If you need a refresher on how to send transactions to a wallet for approval, have a look at the [Wallets lesson](./interact-with-wallets.md).
 

--- a/content/token-swap.md
+++ b/content/token-swap.md
@@ -415,7 +415,7 @@ transaction.add(instruction)
 
 ## Curves
 
-Trading curves are at the core of how swap pools and AMMs (Automated Market Makers) operate. The trading curve is the function that the Token Swap Program uses to calculate how much of a destination token will be provided given an amount of source token. The curve effectively sets the market price of the tokens in the pool.
+Trading curves are at the core of how swap pools and AMMs (Automated Market Makers) operate. The trading curve is the function that the Token Swap Program uses to calculate how much of a destination token will be provided given an amount of source token. The curve sets the market price of the tokens in the pool.
 
 The pool we’ll be interacting with in this lesson employs a [Constant Product](https://spl.solana.com/token-swap#curves) Curve Function. The constant product curve is the well-known Uniswap and Balancer style curve that preserves an invariant on all swaps. This invariant can be expressed as the product of the quantity of token A and token B in the swap pool.
 

--- a/content/versioned-transaction.md
+++ b/content/versioned-transaction.md
@@ -664,7 +664,7 @@ async function initializeLookupTable(
 }
 ```
 
-Congratulations! If you feel good about this demo, you're probably ready to work with lookup tables and versioned transactions on your own. If you want to take a look at the final solution code you can find it on the solution branch [here](https://github.com/Unboxed-Software/solana-versioned-transactions/tree/solution).
+Congratulations! If you feel good about this demo, you're probably ready to work with lookup tables and versioned transactions on your own. If you want to take a look at the final solution code you can [find it on the solution branch](https://github.com/Unboxed-Software/solana-versioned-transactions/tree/solution).
 
 # Challenge
 


### PR DESCRIPTION
~fix: grammar: apostrophe of possession is commonly dropped with inanimate items~
fix: use descriptive text for links instead of 'here'
fix: PDAs are objectively *not* public keys. 
fix: solana uses 'secret key' rather than 'private key' per web3.js and https://github.com/solana-foundation/developer-content/blob/main/docs/terminology.md
fix: use wallet standard - there is no need to install adapters for specific wallets anymore, Jordan Sexton can give details
fix: avoid overuse of the word 'effectively'