### PR TITLE
fix: link to atas-are-pdas.svg in Token Program lesson

### DIFF
--- a/content/token-program.md
+++ b/content/token-program.md
@@ -185,7 +185,7 @@ async function buildCreateTokenAccountTransaction(
 
 An Associated Token Account is a Token Account where the address of the Token Account is derived using an owner's public key and a token mint. Associated Token Accounts provide a deterministic way to find the Token Account owned by a specific `publicKey` for a specific token mint. Most of the time you create a Token Account, you'll want it to be an Associated Token Account.
 
-![ATAs are PDAs](../../assets/atas-are-pdas.svg)
+![ATAs are PDAs](../assets/atas-are-pdas.svg)
 
 Similar to above, you can create an associated token account using the `spl-token` library's `createAssociatedTokenAccount` function.
 


### PR DESCRIPTION
fixes #230

the fix renders the svg correctly in the github preview:
https://github.com/bwnnwtt/solana-course/blob/fix/token-program-lesson/content/token-program.md
![image](https://github.com/Unboxed-Software/solana-course/assets/19340445/74821c4b-6f27-44df-bf0e-e0340d1e7a2e)
