### PR TITLE
Add objectives to es content markdown

### DIFF
--- a/content/es/account-data-matching.md
+++ b/content/es/account-data-matching.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de coincidencia de datos de cuenta
+objectives:
 - Explicar los riesgos de seguridad asociados con la falta de comprobaciones de validación de datos
 - Implementar comprobaciones de validación de datos utilizando Rust de formato largo
 - Implementar comprobaciones de validación de datos utilizando restricciones de anclaje

--- a/content/es/anchor-cpi.md
+++ b/content/es/anchor-cpi.md
@@ -1,5 +1,6 @@
 ---
 title: Anclar los objetivos de IPC y Errores.
+objectives:
 - Haga Invocaciones de Programas Cruzados (CPI) de un programa Anchor
 - Utilice la `cpi` función para generar funciones auxiliares para invocar instrucciones en los programas de Anchor existentes
 - Usar `invoke` y `invoke_signed` hacer CPI donde las funciones de ayuda de CPI no están disponibles

--- a/content/es/anchor-pdas.md
+++ b/content/es/anchor-pdas.md
@@ -1,5 +1,6 @@
 ---
 title: Anclar los PDA y los objetivos de las cuentas
+objectives:
 - Utilice las `bump` restricciones `seeds` y para trabajar con cuentas PDA en Anchor
 - Habilitar y usar la `init_if_needed` restricción
 - Utilice la `realloc` restricción para reasignar espacio en una cuenta existente

--- a/content/es/arbitrary-cpi.md
+++ b/content/es/arbitrary-cpi.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos arbitrarios del IPC
+objectives:
 - Explicar los riesgos de seguridad asociados con la invocación de un IPC a un programa desconocido
 - Muestre cómo el módulo CPI de Anchor evita que esto suceda al realizar un CPI de un programa de Anchor a otro
 - Hacer de forma segura un CPI de un programa de anclaje a un programa arbitrario que no sea de anclaje

--- a/content/es/bump-seed-canonicalization.md
+++ b/content/es/bump-seed-canonicalization.md
@@ -1,5 +1,6 @@
 ---
 título: Bump Seed Canonicalization objetivos
+objectives:
 - Explicar las vulnerabilidades asociadas con el uso de PDA derivados sin el bache canónico
 - Inicializar un PDA usando Anchor 's `seeds` y `bump` restricciones para usar automáticamente el bache canónico
 - Use Anchor 's `seeds` y `bump` restricciones para asegurarse de que la protuberancia canónica siempre se use en futuras instrucciones al derivar un PDA

--- a/content/es/closing-accounts.md
+++ b/content/es/closing-accounts.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de las cuentas de cierre y los ataques de reactivación
+objectives:
 - Explicar las diversas vulnerabilidades de seguridad asociadas con el cierre incorrecto de las cuentas del programa
 - Cierre las cuentas del programa de forma segura con Rust nativo
 - Cierre las cuentas del programa de forma segura utilizando la `close` restricción Anchor

--- a/content/es/cpi.md
+++ b/content/es/cpi.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de las Invocaciones del Programa Cruzado
+objectives:
 - Explicar las invocaciones de programas cruzados (CPI)
 - Describir cómo construir y usar los IPC
 - Explicar cómo un programa proporciona una firma para un PDA

--- a/content/es/deserialize-custom-data.md
+++ b/content/es/deserialize-custom-data.md
@@ -1,5 +1,6 @@
 ---
 title: Deserializar los objetivos de los datos de la cuenta personalizada
+objectives:
 - Explicar cuentas derivadas del programa
 - Derivar PDAs dadas semillas específicas
 - Obtener las cuentas de un programa

--- a/content/es/deserialize-instruction-data.md
+++ b/content/es/deserialize-instruction-data.md
@@ -1,5 +1,6 @@
 ---
 title: Crear un Programa Básico, Parte 1 - Manejar los objetivos de los Datos de Instrucción
+objectives:
 - Asignar variables mutables e inmutables en Rust
 - Crear y usar estructuras y enumeraciones de óxido
 - Usar declaraciones de coincidencia de óxido

--- a/content/es/duplicate-mutable-accounts.md
+++ b/content/es/duplicate-mutable-accounts.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de las cuentas mutables duplicadas
+objectives:
 - Explicar los riesgos de seguridad asociados con las instrucciones que requieren dos cuentas mutables del mismo tipo y cómo evitarlos
 - Implementar una verificación de cuentas mutables duplicadas utilizando Rust de formato largo
 - Implementar una verificación de cuentas mutables duplicadas utilizando las restricciones de Anchor

--- a/content/es/env-variables.md
+++ b/content/es/env-variables.md
@@ -1,5 +1,6 @@
 ---
 title: Variables de entorno en los objetivos de los Programas Solana
+objectives:
 - Definir características del programa en el `Cargo.toml` archivo
 - Utilice el `cfg` atributo Rust para compilar código condicionalmente en función de qué características están o no habilitadas
 - Utilice la `cfg!` macro Rust para compilar código condicionalmente en función de qué características están o no habilitadas

--- a/content/es/getting-started.md
+++ b/content/es/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de la guía del curso
+objectives:
 - explicar cómo está estructurado este curso de Solana
 ---
 

--- a/content/es/hello-world-program.md
+++ b/content/es/hello-world-program.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de Hello World
+objectives:
 - Utilice el sistema del módulo Rust
 - Definir una función en Rust
 - Explicar el `Result` tipo

--- a/content/es/interact-with-wallets.md
+++ b/content/es/interact-with-wallets.md
@@ -1,5 +1,6 @@
 ---
 title: Interactúa con los objetivos de Wallets
+objectives:
 - Explicar monederos
 - Instalar extensión fantasma
 - Establecer cartera fantasma en [Devnet](https://api.devnet.solana.com/)

--- a/content/es/intro-to-anchor-frontend.md
+++ b/content/es/intro-to-anchor-frontend.md
@@ -1,5 +1,6 @@
 ---
 title: Introducción a los objetivos de desarrollo de Anchor del lado del cliente
+objectives:
 - Utilice un IDL para interactuar con un programa Solana del cliente
 - Explicar un `Provider` objeto de anclaje
 - Explicar un `Program` objeto de anclaje

--- a/content/es/intro-to-anchor.md
+++ b/content/es/intro-to-anchor.md
@@ -1,5 +1,6 @@
 ---
 title: Introducción a los objetivos de desarrollo de Anchor
+objectives:
 - Usar el framework de Anchor para construir un programa básico
 - Describir la estructura básica de un programa de anclaje
 - Explicar cómo implementar la validación básica de la cuenta y los controles de seguridad con Anchor

--- a/content/es/intro-to-reading-data.md
+++ b/content/es/intro-to-reading-data.md
@@ -1,5 +1,6 @@
 ---
 title: Lea los datos de los objetivos de la red Solana
+objectives:
 - Explicar cuentas
 - Explicar SOL y lamports
 - Explicar claves públicas

--- a/content/es/intro-to-writing-data.md
+++ b/content/es/intro-to-writing-data.md
@@ -1,5 +1,6 @@
 ---
 title: Escribir datos a los objetivos de la red Solana
+objectives:
 - Explicar el par de teclas
 - Utilizar `@solana/web3.js` para generar un par de claves
 - Usar `@solana/web3.js` para crear un par de claves usando una clave secreta

--- a/content/es/local-setup.md
+++ b/content/es/local-setup.md
@@ -1,5 +1,6 @@
 ---
 título: Objetivos de desarrollo del programa local
+objectives:
 - Crear un entorno local para el desarrollo del programa Solana
 - Usar comandos CLI básicos de Solana
 - Ejecutar un validador de prueba local

--- a/content/es/nfts-with-metaplex.md
+++ b/content/es/nfts-with-metaplex.md
@@ -1,5 +1,6 @@
 ---
 title: Crear NFT de Solana con objetivos Metaplex
+objectives:
 - Explicar los NFT y cómo están representados en la red de Solana
 - Explicar el papel de Metaplex en el ecosistema NFT de Solana
 - Crear y actualizar NFTs usando el SDK Metaplex

--- a/content/es/owner-checks.md
+++ b/content/es/owner-checks.md
@@ -1,5 +1,6 @@
 ---
 title: El propietario comprueba los objetivos
+objectives:
 - Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del propietario
 - Implementar comprobaciones de propietario usando Rust de formato largo
 - Utilice el `Account<'info, T>` envoltorio de Anchor y un tipo de cuenta para automatizar los cheques de propietario

--- a/content/es/paging-ordering-filtering-data.md
+++ b/content/es/paging-ordering-filtering-data.md
@@ -1,7 +1,6 @@
 ---
 title: Page, Order, and Filter Program Data 
-
-Objectives:
+objectives:
 - Páginas, pedidos y filtros de cuentas
 - Obtener cuentas sin datos
 - Determinar dónde se almacenan los datos específicos en el diseño del búfer de una cuenta

--- a/content/es/pda-sharing.md
+++ b/content/es/pda-sharing.md
@@ -1,5 +1,6 @@
 ---
-title: Objetivos de PDA Sharing:
+title: PDA Sharing
+objectives:
 - Explicar los riesgos de seguridad asociados con el uso compartido de PDA
 - Derivar PDA que tienen dominios de autoridad discretos
 - Usar Anchor 's `seeds` y `bump` restricciones para validar cuentas PDA

--- a/content/es/pda.md
+++ b/content/es/pda.md
@@ -1,5 +1,6 @@
 ---
-title: Objetivos del PDAS:
+title: PDAS
+objectives:
 - Explicar las direcciones derivadas del programa (PDA)
 - Explicar varios casos de uso de PDA
 - Describir cómo se derivan los PDA

--- a/content/es/program-security.md
+++ b/content/es/program-security.md
@@ -1,5 +1,6 @@
 ---
-title: Crear un Programa Básico, Parte 3 - Objetivos Básicos de Seguridad y Validación:
+title: Crear un Programa Básico, Parte 3 - Objetivos Básicos de Seguridad y Validación
+objectives:
 - Explicar la importancia de "pensar como un atacante"
 - Comprender las prácticas básicas de seguridad
 - Realizar comprobaciones del propietario

--- a/content/es/program-state-management.md
+++ b/content/es/program-state-management.md
@@ -1,5 +1,6 @@
 ---
-title: Crear un Programa Básico, Parte 2 - Objetivos de la Administración del Estado:
+title: Crear un Programa Básico, Parte 2 - Objetivos de la Administración del Estado
+objectives:
 - Describir el proceso de creación de una nueva cuenta utilizando una dirección derivada del programa (PDA)
 - Usar semillas para derivar un PDA
 - Utilice el espacio requerido por una cuenta para calcular la cantidad de alquiler (en lamports) que un usuario debe asignar

--- a/content/es/reinitialization-attacks.md
+++ b/content/es/reinitialization-attacks.md
@@ -1,5 +1,6 @@
 ---
-title: Reinicialización Ataques objetivos:
+title: Reinicialización Ataques
+objectives:
 - Explicar los riesgos de seguridad asociados con una vulnerabilidad de reinicialización
 - Utilice la comprobación de óxido de formato largo si una cuenta ya se ha inicializado
 - Usar la `init` restricción de Anchor para inicializar cuentas, que establece automáticamente un discriminador de cuenta que se comprueba para evitar la reinicialización de una cuenta

--- a/content/es/security-intro.md
+++ b/content/es/security-intro.md
@@ -1,5 +1,6 @@
 ---
 title: Cómo abordar los objetivos del módulo de seguridad del programa
+objectives:
 - entender cómo abordar el Módulo de seguridad del programa
 ---
 

--- a/content/es/serialize-instruction-data.md
+++ b/content/es/serialize-instruction-data.md
@@ -1,5 +1,6 @@
 ---
 title: Serializar los objetivos de los datos de instrucción personalizados
+objectives:
 - Explicar el contenido de una transacción
 - Explicar las instrucciones de transacción
 - Explicar los conceptos básicos de las optimizaciones de tiempo de ejecución de Solana

--- a/content/es/signer-auth.md
+++ b/content/es/signer-auth.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de la autorización del firmante
+objectives:
 - Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del firmante
 - Implementar comprobaciones de firmantes utilizando Rust de formato largo
 - Implementar comprobaciones de firmantes utilizando el `Signer` tipo de Anchor

--- a/content/es/solana-pay.md
+++ b/content/es/solana-pay.md
@@ -1,5 +1,6 @@
 ---
 title: Crear Tokens con los objetivos del Programa Token
+objectives:
 - Crear fichas de menta
 - Crear cuentas de token
 - Tokens de menta

--- a/content/es/token-program.md
+++ b/content/es/token-program.md
@@ -1,5 +1,6 @@
 ---
 title: Crear Tokens con los objetivos del Programa Token
+objectives:
 - Crear fichas de menta
 - Crear cuentas de token
 - Tokens de menta

--- a/content/es/token-swap.md
+++ b/content/es/token-swap.md
@@ -1,5 +1,6 @@
 ---
 title: Tokens de intercambio con los objetivos del Programa de intercambio de tokens
+objectives:
 - Crear un grupo de intercambio de tokens
 - Liquidez de depósitos
 - Retirar liquidez

--- a/content/es/type-cosplay.md
+++ b/content/es/type-cosplay.md
@@ -1,5 +1,6 @@
 ---
 title: Tipo Objetivos del cosplay
+objectives:
 - Explicar los riesgos de seguridad asociados con no verificar los tipos de cuenta
 - Implementar un discriminador de tipo de cuenta usando Rust de formato largo
 - Utilice la `init` restricción de Anchor para inicializar cuentas

--- a/content/es/versioned-transaction.md
+++ b/content/es/versioned-transaction.md
@@ -1,5 +1,6 @@
 ---
 title: Objetivos de Transacciones Versionadas y Tablas de Búsqueda
+objectives:
 - Crear transacciones versionadas
 - Crear tablas de búsqueda
 - Extender tablas de búsqueda


### PR DESCRIPTION
Fix `es` content markdown by adding `objectives:` to initial yaml.