### PR TITLE
refactor: move objectives into course structure

### DIFF
--- a/content/account-data-matching.md
+++ b/content/account-data-matching.md
@@ -1,11 +1,3 @@
----
-title: Account Data Matching
-objectives:
-- Explain the security risks associated with missing data validation checks
-- Implement data validation checks using long-form Rust
-- Implement data validation checks using Anchor constraints
----
-
 # TL;DR
 
 - Use **data validation checks** to verify that account data matches an expected value**.** Without appropriate data validations checks, unexpected accounts may be used in an instruction.

--- a/content/anchor-cpi.md
+++ b/content/anchor-cpi.md
@@ -1,12 +1,3 @@
----
-title: Anchor CPIs and Errors
-objectives:
-- Make Cross Program Invocations (CPIs) from an Anchor program
-- Use the `cpi` feature to generate helper functions for invoking instructions on existing Anchor programs
-- Use `invoke` and `invoke_signed` to make CPIs where CPI helper functions are unavailable
-- Create and return custom Anchor errors
----
-
 # TL;DR
 
 - Anchor provides a simplified way to create CPIs using a **`CpiContext`**

--- a/content/anchor-pdas.md
+++ b/content/anchor-pdas.md
@@ -1,12 +1,3 @@
----
-title: Anchor PDAs and Accounts
-objectives:
-- Use the `seeds` and `bump` constraints to work with PDA accounts in Anchor
-- Enable and use the `init_if_needed` constraint
-- Use the `realloc` constraint to reallocate space on an existing account
-- Use the `close` constraint to close an existing account
----
-
 # TL;DR
 
 - The `seeds` and `bump` constraints are used to initialize and validate PDA accounts in Anchor

--- a/content/arbitrary-cpi.md
+++ b/content/arbitrary-cpi.md
@@ -1,11 +1,3 @@
----
-title: Arbitrary CPI
-objectives:
-- Explain the security risks associated with invoking a CPI to an unknown program
-- Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another
-- Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program
----
-
 # TL;DR
 
 - To generate a CPI, the target program must be passed into the invoking instruction as an account. This means that any target program could be passed into the instruction. Your program should check for incorrect or unexpected programs.

--- a/content/bump-seed-canonicalization.md
+++ b/content/bump-seed-canonicalization.md
@@ -1,11 +1,3 @@
----
-title: Bump Seed Canonicalization
-objectives:
-- Explain the vulnerabilities associated with using PDAs derived without the canonical bump
-- Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump
-- Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA
----
-
 # TL;DR
 
 - The [**`create_program_address`**](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) function derives a PDA without searching for the **canonical bump**. This means there are multiple valid bumps, all of which will produce different addresses.

--- a/content/closing-accounts.md
+++ b/content/closing-accounts.md
@@ -1,11 +1,3 @@
----
-title: Closing Accounts and Revival Attacks
-objectives:
-- Explain the various security vulnerabilities associated with closing program accounts incorrectly
-- Close program accounts safely and securely using native Rust
-- Close program accounts safely and securely using the Anchor `close` constraint
----
-
 # TL;DR
 
 - **Closing an account** improperly creates an opportunity for reinitialization/revival attacks

--- a/content/compressed-nfts.md
+++ b/content/compressed-nfts.md
@@ -1,12 +1,3 @@
----
-title: Compressed NFTs
-objectives:
-- Create a compressed NFT collection using Metaplex’s Bubblegum program
-- Mint compressed NFTs using the Bubblegum TS SDK
-- Transfer compressed NFTs using the Bubblegum TS SDK
-- Read compressed NFT data using the Read API
----
-
 # TL;DR
 
 - **Compressed NFTs (cNFTs)** use **State Compression** to hash NFT data and store the hash on-chain in an account using a **concurrent merkle tree** structure

--- a/content/cpi.md
+++ b/content/cpi.md
@@ -1,12 +1,3 @@
----
-title: Cross Program Invocations
-objectives:
-- Explain Cross-Program Invocations (CPIs)
-- Describe how to construct and use CPIs
-- Explain how a program provides a signature for a PDA
-- Avoid common pitfalls and troubleshoot common errors associated with CPIs
----
-
 # TL;DR
 
 - A **Cross-Program Invocation (CPI)** is a call from one program to another, targeting a specific instruction on the program called

--- a/content/deserialize-custom-data.md
+++ b/content/deserialize-custom-data.md
@@ -1,12 +1,3 @@
----
-title: Deserialize Program Data
-objectives:
-- Explain Program Derived Accounts
-- Derive PDAs given specific seeds
-- Fetch a program’s accounts
-- Use Borsh to deserialize custom data
----
-
 # TL;DR
 
 - Programs store data in PDAs, which stands for **Program Derived Address**. 

--- a/content/deserialize-instruction-data.md
+++ b/content/deserialize-instruction-data.md
@@ -1,15 +1,3 @@
----
-title: Create a Basic Program, Part 1 - Handle Instruction Data
-objectives:
-- Assign mutable and immutable variables in Rust
-- Create and use Rust structs and enums
-- Use Rust match statements
-- Add implementations to Rust types
-- Deserialize instruction data into Rust data types
-- Execute different program logic for different types of instructions
-- Explain the structure of a smart contract on Solana
----
-
 # TL;DR
 
 - Most programs support **multiple discrete instructions** - you decide when writing your program what these instructions are and what data must accompany them

--- a/content/duplicate-mutable-accounts.md
+++ b/content/duplicate-mutable-accounts.md
@@ -1,11 +1,3 @@
----
-title: Duplicate Mutable Accounts
-objectives:
-- Explain the security risks associated with instructions that require two mutable accounts of the same type and how to avoid them
-- Implement a check for duplicate mutable accounts using long-form Rust
-- Implement a check for duplicate mutable accounts using Anchor constraints
----
-
 # TL;DR
 
 - When an instruction requires two mutable accounts of the same type, an attacker can pass in the same account twice, causing the account to be mutated in unintended ways.

--- a/content/env-variables.md
+++ b/content/env-variables.md
@@ -1,12 +1,3 @@
----
-title: Environment Variables in Solana Programs
-objectives:
-- Define program features in the `Cargo.toml` file
-- Use the Rust `cfg` attribute to conditionally compile code based on which features are or are not enabled
-- Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled
-- Create an admin-only instruction to set up a program account that can be used to store program configuration values
----
-
 # TL;DR
 
 -   There are no "out of the box" solutions for creating distinct environments in an on-chain program, but you can achieve something similar to environment variables if you get creative.

--- a/content/es/account-data-matching.md
+++ b/content/es/account-data-matching.md
@@ -1,11 +1,3 @@
----
-title: Objetivos de coincidencia de datos de cuenta
-objectives:
-- Explicar los riesgos de seguridad asociados con la falta de comprobaciones de validación de datos
-- Implementar comprobaciones de validación de datos utilizando Rust de formato largo
-- Implementar comprobaciones de validación de datos utilizando restricciones de anclaje
----
-
 # TL;DR
 
 - Usar **comprobaciones de validación de datos** para verificar que los datos de la cuenta coincidan con un valor esperado**.** Sin las comprobaciones de validación de datos apropiadas, se pueden usar cuentas inesperadas en una instrucción.

--- a/content/es/anchor-cpi.md
+++ b/content/es/anchor-cpi.md
@@ -1,12 +1,3 @@
----
-title: Anclar los objetivos de IPC y Errores.
-objectives:
-- Haga Invocaciones de Programas Cruzados (CPI) de un programa Anchor
-- Utilice la `cpi` función para generar funciones auxiliares para invocar instrucciones en los programas de Anchor existentes
-- Usar `invoke` y `invoke_signed` hacer CPI donde las funciones de ayuda de CPI no están disponibles
-- Crear y devolver errores de anclaje personalizados
----
-
 # TL;DR
 
 -   Anchor proporciona una forma simplificada de crear IPC utilizando un ** `CpiContext` **

--- a/content/es/anchor-pdas.md
+++ b/content/es/anchor-pdas.md
@@ -1,12 +1,3 @@
----
-title: Anclar los PDA y los objetivos de las cuentas
-objectives:
-- Utilice las `bump` restricciones `seeds` y para trabajar con cuentas PDA en Anchor
-- Habilitar y usar la `init_if_needed` restricción
-- Utilice la `realloc` restricción para reasignar espacio en una cuenta existente
-- Utilice la `close` restricción para cerrar una cuenta existente
----
-
 # TL;DR
 
 -   Las `bump` restricciones `seeds` and se utilizan para inicializar y validar cuentas PDA en Anchor

--- a/content/es/arbitrary-cpi.md
+++ b/content/es/arbitrary-cpi.md
@@ -1,11 +1,3 @@
----
-title: Objetivos arbitrarios del IPC
-objectives:
-- Explicar los riesgos de seguridad asociados con la invocación de un IPC a un programa desconocido
-- Muestre cómo el módulo CPI de Anchor evita que esto suceda al realizar un CPI de un programa de Anchor a otro
-- Hacer de forma segura un CPI de un programa de anclaje a un programa arbitrario que no sea de anclaje
----
-
 # TL;DR
 
 -   Para generar un CPI, el programa de destino debe pasar a la instrucción de invocación como una cuenta. Esto significa que cualquier programa objetivo podría pasar a la instrucción. Su programa debe verificar si hay programas incorrectos o inesperados.

--- a/content/es/bump-seed-canonicalization.md
+++ b/content/es/bump-seed-canonicalization.md
@@ -1,11 +1,3 @@
----
-título: Bump Seed Canonicalization objetivos
-objectives:
-- Explicar las vulnerabilidades asociadas con el uso de PDA derivados sin el bache canónico
-- Inicializar un PDA usando Anchor 's `seeds` y `bump` restricciones para usar automáticamente el bache canónico
-- Use Anchor 's `seeds` y `bump` restricciones para asegurarse de que la protuberancia canónica siempre se use en futuras instrucciones al derivar un PDA
----
-
 # TL;DR
 
 -   La función [** `create_program_address` **](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) deriva un PDA sin buscar el**protuberancia canónica**. Esto significa que hay múltiples baches válidos, todos los cuales producirán diferentes direcciones.

--- a/content/es/closing-accounts.md
+++ b/content/es/closing-accounts.md
@@ -1,11 +1,3 @@
----
-title: Objetivos de las cuentas de cierre y los ataques de reactivación
-objectives:
-- Explicar las diversas vulnerabilidades de seguridad asociadas con el cierre incorrecto de las cuentas del programa
-- Cierre las cuentas del programa de forma segura con Rust nativo
-- Cierre las cuentas del programa de forma segura utilizando la `close` restricción Anchor
----
-
 # TL;DR
 
 -   crea **Cerrar una cuenta** incorrectamente una oportunidad para ataques de reinicialización/reactivación

--- a/content/es/cpi.md
+++ b/content/es/cpi.md
@@ -1,12 +1,3 @@
----
-title: Objetivos de las Invocaciones del Programa Cruzado
-objectives:
-- Explicar las invocaciones de programas cruzados (CPI)
-- Describir cómo construir y usar los IPC
-- Explicar cómo un programa proporciona una firma para un PDA
-- Evite las trampas comunes y solucione los errores comunes asociados con los IPC
----
-
 # TL;DR
 
 -   A **Invocación de programa cruzado (CPI)** es una llamada de un programa a otro, dirigida a una instrucción específica en el programa llamado

--- a/content/es/deserialize-custom-data.md
+++ b/content/es/deserialize-custom-data.md
@@ -1,12 +1,3 @@
----
-title: Deserializar los objetivos de los datos de la cuenta personalizada
-objectives:
-- Explicar cuentas derivadas del programa
-- Derivar PDAs dadas semillas específicas
-- Obtener las cuentas de un programa
-- Usar Borsh para deserializar datos personalizados
----
-
 # TL;DR
 
 -   **Direcciones derivadas del programa**, o PDA, son direcciones que no tienen una clave privada correspondiente. El concepto de PDA permite que los programas firmen transacciones por sí mismos y permite almacenar y localizar datos.

--- a/content/es/deserialize-instruction-data.md
+++ b/content/es/deserialize-instruction-data.md
@@ -1,15 +1,3 @@
----
-title: Crear un Programa Básico, Parte 1 - Manejar los objetivos de los Datos de Instrucción
-objectives:
-- Asignar variables mutables e inmutables en Rust
-- Crear y usar estructuras y enumeraciones de óxido
-- Usar declaraciones de coincidencia de óxido
-- Añadir implementaciones a los tipos de óxido
-- Deserializar los datos de instrucción en tipos de datos de óxido
-- Ejecutar diferentes lógicas de programa para diferentes tipos de instrucciones
-- Explicar la estructura de un contrato inteligente en Solana
----
-
 # TL;DR
 
 -   La mayoría de los programas admiten**instrucciones discretas múltiples** : usted decide al escribir su programa cuáles son estas instrucciones y qué datos deben acompañarlas.

--- a/content/es/duplicate-mutable-accounts.md
+++ b/content/es/duplicate-mutable-accounts.md
@@ -1,11 +1,3 @@
----
-title: Objetivos de las cuentas mutables duplicadas
-objectives:
-- Explicar los riesgos de seguridad asociados con las instrucciones que requieren dos cuentas mutables del mismo tipo y cómo evitarlos
-- Implementar una verificación de cuentas mutables duplicadas utilizando Rust de formato largo
-- Implementar una verificación de cuentas mutables duplicadas utilizando las restricciones de Anchor
----
-
 # TL;DR
 
 -   Cuando una instrucción requiere dos cuentas mutables del mismo tipo, un atacante puede pasar en la misma cuenta dos veces, lo que hace que la cuenta se mute de manera involuntaria.

--- a/content/es/env-variables.md
+++ b/content/es/env-variables.md
@@ -1,12 +1,3 @@
----
-title: Variables de entorno en los objetivos de los Programas Solana
-objectives:
-- Definir características del programa en el `Cargo.toml` archivo
-- Utilice el `cfg` atributo Rust para compilar código condicionalmente en función de qué características están o no habilitadas
-- Utilice la `cfg!` macro Rust para compilar código condicionalmente en función de qué características están o no habilitadas
-- Crear una instrucción de solo administrador para configurar una cuenta de programa que se pueda usar para almacenar valores de configuración del programa
----
-
 # TL;DR
 
 -   No hay soluciones "listas para usar" para crear entornos distintos en un programa en cadena, pero puede lograr algo similar a las variables de entorno si se vuelve creativo.

--- a/content/es/getting-started.md
+++ b/content/es/getting-started.md
@@ -1,9 +1,3 @@
----
-title: Objetivos de la guía del curso
-objectives:
-- explicar cómo está estructurado este curso de Solana
----
-
 ## ¿Cómo está estructurado este curso?
 
 Me alegra que hayas preguntado. Cada lección comienza con una lista de los objetivos de la lección. Estas son declaraciones breves que indican lo que aprenderá a lo largo de la lección.

--- a/content/es/hello-world-program.md
+++ b/content/es/hello-world-program.md
@@ -1,14 +1,3 @@
----
-title: Objetivos de Hello World
-objectives:
-- Utilice el sistema del módulo Rust
-- Definir una función en Rust
-- Explicar el `Result` tipo
-- Explicar el punto de entrada a un programa de Solana
-- Construir e implementar un programa básico de Solana
-- Envíe una transacción para invocar nuestro programa "¡Hola, mundo!"
----
-
 # TL;DR
 
 -   **Programas** en Solana son un tipo particular de cuenta que almacena y ejecuta lógica de instrucciones

--- a/content/es/interact-with-wallets.md
+++ b/content/es/interact-with-wallets.md
@@ -1,12 +1,3 @@
----
-title: Interactúa con los objetivos de Wallets
-objectives:
-- Explicar monederos
-- Instalar extensión fantasma
-- Establecer cartera fantasma en [Devnet](https://api.devnet.solana.com/)
-- Utilice el adaptador de billetera para que los usuarios firmen transacciones
----
-
 # TL;DR
 
 -   **Carteras** almacenar su clave secreta y manejar la firma de transacciones seguras

--- a/content/es/intro-to-anchor-frontend.md
+++ b/content/es/intro-to-anchor-frontend.md
@@ -1,14 +1,3 @@
----
-title: Introducción a los objetivos de desarrollo de Anchor del lado del cliente
-objectives:
-- Utilice un IDL para interactuar con un programa Solana del cliente
-- Explicar un `Provider` objeto de anclaje
-- Explicar un `Program` objeto de anclaje
-- Utilice el Ancla `MethodsBuilder` para crear instrucciones y transacciones
-- Usar Anchor para recuperar cuentas
-- Configurar un frontend para invocar instrucciones usando Anchor y un IDL
----
-
 # TL;DR
 
 -   An **IDL** es un archivo que representa la estructura de un programa de Solana. Los programas escritos y construidos usando Anchor generan automáticamente un IDL correspondiente. IDL son las siglas de Interface Description Language.

--- a/content/es/intro-to-anchor.md
+++ b/content/es/intro-to-anchor.md
@@ -1,11 +1,3 @@
----
-title: Introducción a los objetivos de desarrollo de Anchor
-objectives:
-- Usar el framework de Anchor para construir un programa básico
-- Describir la estructura básica de un programa de anclaje
-- Explicar cómo implementar la validación básica de la cuenta y los controles de seguridad con Anchor
----
-
 # TL;DR
 
 -   **Ancla** es un marco para construir programas Solana

--- a/content/es/intro-to-reading-data.md
+++ b/content/es/intro-to-reading-data.md
@@ -1,16 +1,3 @@
----
-title: Lea los datos de los objetivos de la red Solana
-objectives:
-- Explicar cuentas
-- Explicar SOL y lamports
-- Explicar claves públicas
-- Explicar la API de JSON RPC
-- Explicar web3.js
-- Instalar web3.js
-- Utilice web3.js para crear una conexión a un nodo de Solana
-- Utilice web3.js para leer datos de la cadena de bloques (saldo, información de la cuenta, etc.)
----
-
 ## TL;DR
 
 -   **Cuentas** son como los archivos en el libro mayor de red de Solana. Todos los datos de estado se almacenan en una cuenta. Las cuentas se pueden usar para muchas cosas, pero por ahora nos centraremos en el aspecto de las cuentas que almacenan SOL.

--- a/content/es/intro-to-writing-data.md
+++ b/content/es/intro-to-writing-data.md
@@ -1,16 +1,3 @@
----
-title: Escribir datos a los objetivos de la red Solana
-objectives:
-- Explicar el par de teclas
-- Utilizar `@solana/web3.js` para generar un par de claves
-- Usar `@solana/web3.js` para crear un par de claves usando una clave secreta
-- Explicar transacciones
-- Explicar las tarifas de transacción
-- Usar `@solana/web3.js` para enviar sol
-- Utilizar `@solana/web3.js` para firmar transacciones
-- Utilice Solana Explorer para ver las transacciones
----
-
 # TL;DR
 
 -   **Par de llaves** se refiere a un emparejamiento de claves públicas y secretas. La clave pública se utiliza como una "dirección" que apunta a una cuenta en la red Solana. La clave secreta se utiliza para verificar la identidad o la autoridad. Como su nombre indica, siempre debe mantener las claves secretas*privado*. `@solana/web3.js` Proporciona funciones de ayuda para crear un nuevo par de claves o para construir un par de claves utilizando una clave secreta existente.

--- a/content/es/local-setup.md
+++ b/content/es/local-setup.md
@@ -1,13 +1,3 @@
----
-título: Objetivos de desarrollo del programa local
-objectives:
-- Crear un entorno local para el desarrollo del programa Solana
-- Usar comandos CLI básicos de Solana
-- Ejecutar un validador de prueba local
-- Utilice Rust y Solana CLI para implementar un programa Solana desde su entorno de desarrollo local
-- Utilice la CLI de Solana para ver los registros del programa
----
-
 # TL;DR
 
 -   Para comenzar con Solana localmente, primero deberá instalar **Herrumbre** y **Solana CLI**

--- a/content/es/nfts-with-metaplex.md
+++ b/content/es/nfts-with-metaplex.md
@@ -1,12 +1,3 @@
----
-title: Crear NFT de Solana con objetivos Metaplex
-objectives:
-- Explicar los NFT y cómo están representados en la red de Solana
-- Explicar el papel de Metaplex en el ecosistema NFT de Solana
-- Crear y actualizar NFTs usando el SDK Metaplex
-- Explicar la funcionalidad básica del programa Token Metadata, el programa Candy Machine y Sugar CLI como herramientas que ayudan a crear y distribuir NFT en Solana
----
-
 # TL;DR
 
 -   **Tokens no fungibles (NFT)** se representan en Solana como tokens SPL con una cuenta de metadatos asociada, 0 decimales y un suministro máximo de 1

--- a/content/es/owner-checks.md
+++ b/content/es/owner-checks.md
@@ -1,12 +1,3 @@
----
-title: El propietario comprueba los objetivos
-objectives:
-- Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del propietario
-- Implementar comprobaciones de propietario usando Rust de formato largo
-- Utilice el `Account<'info, T>` envoltorio de Anchor y un tipo de cuenta para automatizar los cheques de propietario
-- Utilice la `#[account(owner = <expr>)]` restricción de Anchor para definir explícitamente un programa externo que debería poseer una cuenta.
----
-
 # TL;DR
 
 -   Se utiliza **Cheques del propietario** para verificar que las cuentas son propiedad del programa esperado. Sin cheques de propietario apropiados, las cuentas propiedad de programas inesperados podrían usarse en una instrucción.

--- a/content/es/paging-ordering-filtering-data.md
+++ b/content/es/paging-ordering-filtering-data.md
@@ -1,14 +1,3 @@
----
-title: Page, Order, and Filter Program Data 
-objectives:
-- Páginas, pedidos y filtros de cuentas
-- Obtener cuentas sin datos
-- Determinar dónde se almacenan los datos específicos en el diseño del búfer de una cuenta
-- Obtener cuentas con un subconjunto de datos que se pueden utilizar para ordenar cuentas
-- Obtener solo cuentas cuyos datos coincidan con criterios específicos
-- Obtener un subconjunto de cuentas totales usando `getMultipleAccounts`
----
-
 # TL;DR
 
 -   Esta lección profundiza en algunas funcionalidades de las llamadas RPC que utilizamos en la lección de datos de cuenta de deserialización

--- a/content/es/pda-sharing.md
+++ b/content/es/pda-sharing.md
@@ -1,11 +1,3 @@
----
-title: PDA Sharing
-objectives:
-- Explicar los riesgos de seguridad asociados con el uso compartido de PDA
-- Derivar PDA que tienen dominios de autoridad discretos
-- Usar Anchor 's `seeds` y `bump` restricciones para validar cuentas PDA
----
-
 # TL;DR
 
 - El uso de la misma PDA para múltiples dominios de autoridad abre su programa a la posibilidad de que los usuarios accedan a datos y fondos que no les pertenecen.

--- a/content/es/pda.md
+++ b/content/es/pda.md
@@ -1,13 +1,3 @@
----
-title: PDAS
-objectives:
-- Explicar las direcciones derivadas del programa (PDA)
-- Explicar varios casos de uso de PDA
-- Describir cómo se derivan los PDA
-- Utilice las derivaciones de PDA para localizar y recuperar datos
----
-
-
 # TL;DR
 
 - A **Dirección derivada del programa** (PDA) se deriva de a **iD del programa** y una lista opcional de **semillas**

--- a/content/es/program-security.md
+++ b/content/es/program-security.md
@@ -1,14 +1,3 @@
----
-title: Crear un Programa Básico, Parte 3 - Objetivos Básicos de Seguridad y Validación
-objectives:
-- Explicar la importancia de "pensar como un atacante"
-- Comprender las prácticas básicas de seguridad
-- Realizar comprobaciones del propietario
-- Realizar comprobaciones del firmante
-- Validar cuentas pasadas al programa
-- Realizar validación de datos básicos
----
-
 # TL;DR
 
 - **Pensar como un atacante** significa preguntar "¿Cómo rompo esto?"

--- a/content/es/program-state-management.md
+++ b/content/es/program-state-management.md
@@ -1,13 +1,3 @@
----
-title: Crear un Programa Básico, Parte 2 - Objetivos de la Administración del Estado
-objectives:
-- Describir el proceso de creación de una nueva cuenta utilizando una dirección derivada del programa (PDA)
-- Usar semillas para derivar un PDA
-- Utilice el espacio requerido por una cuenta para calcular la cantidad de alquiler (en lamports) que un usuario debe asignar
-- Utilice una Invocación de programa cruzado (CPI) para inicializar una cuenta con un PDA como la dirección de la nueva cuenta
-- Explicar cómo actualizar los datos almacenados en una nueva cuenta
----
-
 # TL;DR
 
 -   El estado del programa se almacena en otras cuentas en lugar de en el propio programa.

--- a/content/es/reinitialization-attacks.md
+++ b/content/es/reinitialization-attacks.md
@@ -1,11 +1,3 @@
----
-title: Reinicialización Ataques
-objectives:
-- Explicar los riesgos de seguridad asociados con una vulnerabilidad de reinicialización
-- Utilice la comprobación de óxido de formato largo si una cuenta ya se ha inicializado
-- Usar la `init` restricción de Anchor para inicializar cuentas, que establece automáticamente un discriminador de cuenta que se comprueba para evitar la reinicialización de una cuenta
----
-
 # TL;DR
 
 - Use un discriminador de cuenta o una bandera de inicialización para verificar si una cuenta ya se ha inicializado para evitar que una cuenta se reinicie y anule los datos de cuenta existentes.

--- a/content/es/rust-macros.md
+++ b/content/es/rust-macros.md
@@ -1,11 +1,3 @@
----
-title: Rust Procedural Macros
-objectives:
-- Create and use **Procedural Macros** in Rust
-- Explain and work with a Rust Abstract Syntax Tree (AST)
-- Describe how procedural macros are used in the Anchor framework
----
-
 # TL;DR
 
 -   **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.

--- a/content/es/security-intro.md
+++ b/content/es/security-intro.md
@@ -1,9 +1,3 @@
----
-title: Cómo abordar los objetivos del módulo de seguridad del programa
-objectives:
-- entender cómo abordar el Módulo de seguridad del programa
----
-
 El objetivo de este módulo es exponerlo a una amplia variedad de exploits de seguridad comunes que son exclusivos del desarrollo de Solana. Hemos modelado fuertemente este módulo a partir de un repositorio público de GitHub llamado Sealevel Attacks creado por el gran Armani Ferrante.
 
 Podrías estar pensando: "¿No tuvimos una lección de seguridad en el módulo 3?" Sí, ciertamente lo hicimos. Queríamos asegurarnos de que cualquiera que implementara programas en Mainnet fuera de las puertas tuviera al menos una comprensión básica de la seguridad. Y si ese es usted, entonces espero que los principios fundamentales que aprendió en esa lección lo hayan llevado a evitar algunas hazañas comunes de Solana por su cuenta.

--- a/content/es/serialize-instruction-data.md
+++ b/content/es/serialize-instruction-data.md
@@ -1,13 +1,3 @@
----
-title: Serializar los objetivos de los datos de instrucción personalizados
-objectives:
-- Explicar el contenido de una transacción
-- Explicar las instrucciones de transacción
-- Explicar los conceptos básicos de las optimizaciones de tiempo de ejecución de Solana
-- Explicar Borsh
-- Utilice Borsh para serializar datos de instrucciones personalizadas
----
-
 # TL;DR
 
 -   Las transacciones se componen de una serie de instrucciones, una sola transacción puede tener cualquier número de instrucciones, cada una dirigida a su propio programa. Cuando se envía una transacción, el tiempo de ejecución de Solana procesará sus instrucciones en orden y de forma atómica, lo que significa que si alguna de las instrucciones falla por cualquier motivo, toda la transacción no se procesará.

--- a/content/es/signer-auth.md
+++ b/content/es/signer-auth.md
@@ -1,12 +1,3 @@
----
-title: Objetivos de la autorización del firmante
-objectives:
-- Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del firmante
-- Implementar comprobaciones de firmantes utilizando Rust de formato largo
-- Implementar comprobaciones de firmantes utilizando el `Signer` tipo de Anchor
-- Implementar comprobaciones de firmantes utilizando la `#[account(signer)]` restricción de Anchor
----
-
 # TL;DR
 
 -   Utilícelo **Comprobaciones del firmante** para verificar que cuentas específicas hayan firmado una transacción. Sin las comprobaciones apropiadas del firmante, las cuentas pueden ser capaces de ejecutar instrucciones que no deberían estar autorizadas a realizar.

--- a/content/es/solana-pay.md
+++ b/content/es/solana-pay.md
@@ -1,13 +1,3 @@
----
-title: Crear Tokens con los objetivos del Programa Token
-objectives:
-- Crear fichas de menta
-- Crear cuentas de token
-- Tokens de menta
-- Transferir tokens
-- Quemar tokens
----
-
 # TL;DR
 
 -   **SPL-Tokens** representan todos los tokens no nativos en la red Solana. Tanto las fichas fungibles como las no fungibles (NFT) en Solana son SPL-Tokens

--- a/content/es/token-program.md
+++ b/content/es/token-program.md
@@ -1,13 +1,3 @@
----
-title: Crear Tokens con los objetivos del Programa Token
-objectives:
-- Crear fichas de menta
-- Crear cuentas de token
-- Tokens de menta
-- Transferir tokens
-- Quemar tokens
----
-
 # TL;DR
 
 -   **SPL-Tokens** representan todos los tokens no nativos en la red Solana. Tanto las fichas fungibles como las no fungibles (NFT) en Solana son SPL-Tokens

--- a/content/es/token-swap.md
+++ b/content/es/token-swap.md
@@ -1,12 +1,3 @@
----
-title: Tokens de intercambio con los objetivos del Programa de intercambio de tokens
-objectives:
-- Crear un grupo de intercambio de tokens
-- Liquidez de depósitos
-- Retirar liquidez
-- Tokens de swap
----
-
 # TL;DR
 
 -   El **Programa de intercambio de tokens** es un contrato SPL implementado en Devnet disponible para pruebas y experimentación por parte de desarrolladores y protocolos. Para casos de uso de producción, utilice su propia implementación o una mantenida regularmente por un servicio de buena reputación.

--- a/content/es/type-cosplay.md
+++ b/content/es/type-cosplay.md
@@ -1,12 +1,3 @@
----
-title: Tipo Objetivos del cosplay
-objectives:
-- Explicar los riesgos de seguridad asociados con no verificar los tipos de cuenta
-- Implementar un discriminador de tipo de cuenta usando Rust de formato largo
-- Utilice la `init` restricción de Anchor para inicializar cuentas
-- Usar el `Account` tipo de Ancla para la validación de la cuenta
----
-
 # TL;DR
 
 -   Usar discriminadores para distinguir entre diferentes tipos de cuentas

--- a/content/es/versioned-transaction.md
+++ b/content/es/versioned-transaction.md
@@ -1,12 +1,3 @@
----
-title: Objetivos de Transacciones Versionadas y Tablas de Búsqueda
-objectives:
-- Crear transacciones versionadas
-- Crear tablas de búsqueda
-- Extender tablas de búsqueda
-- Usar tablas de búsqueda con transacciones versionadas
----
-
 # TL;DR
 
 -   **Transacciones Versionadas** se refiere a una forma de admitir versiones heredadas y versiones más nuevas de formatos de transacción. El formato de transacción original es "legado" y las nuevas versiones de transacción comienzan en la versión 0. Las transacciones versionadas se implementaron para admitir el uso de tablas de búsqueda de direcciones (también llamadas tablas de búsqueda o LUT).

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -1,13 +1,3 @@
----
-title: Course Guide
-objectives:
-- understand what web3 is
-- understand what Solana is
-- learn how this course is structured
-- know how to get the most from this course
----
-
-
 ## Welcome!
 
 Welcome to the best starting point for developers looking to learn web3 and blockchain!

--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -38,7 +38,7 @@ Compared to older platforms like Bitcoin and Ethereum, Solana is:
 
 - Highly decentralized, having one of the highest Nakamoto coefficient (decentralization score) of any proof-of-stake network.
 
-Many of the common use cases on Solana are only possible on Solana, due to the high costs and slow transation times of older blockchains.
+Many of the common use cases on Solana are only possible on Solana, due to the high costs and slow translation times of older blockchains.
 
 ## What will I learn on this course?
 

--- a/content/hello-world-program.md
+++ b/content/hello-world-program.md
@@ -1,14 +1,3 @@
----
-title: Hello World
-objectives:
-- Use the Rust module system
-- Define a function in Rust
-- Explain the `Result` type
-- Explain the entry point to a Solana program
-- Build and deploy a basic Solana program
-- Submit a transaction to invoke our “Hello, world!” program
----
-
 # TL;DR
 
 - **Programs** on Solana are a particular type of account that stores and executes instruction logic

--- a/content/interact-with-wallets.md
+++ b/content/interact-with-wallets.md
@@ -1,12 +1,3 @@
----
-title: Interact With Wallets
-objectives:
-- Explain wallets
-- Install Phantom extension
-- Set Phantom wallet to [Devnet](https://api.devnet.solana.com/)
-- Use wallet-adapter to have users sign transactions
----
-
 # TL;DR
 
 - **Wallets** store your secret key and handle secure transaction signing

--- a/content/intro-to-anchor-frontend.md
+++ b/content/intro-to-anchor-frontend.md
@@ -1,14 +1,3 @@
----
-title: Intro to client-side Anchor development
-objectives:
-- Use an IDL to interact with a Solana program from the client
-- Explain an Anchor `Provider` object
-- Explain an Anchor `Program` object
-- Use the Anchor `MethodsBuilder` to build instructions and transactions
-- Use Anchor to fetch accounts
-- Set up a frontend to invoke instructions using Anchor and an IDL
----
-
 # TL;DR
 
 - An **IDL** is a file representing the structure of a Solana program. Programs written and built using Anchor automatically generate a corresponding IDL. IDL stands for Interface Description Language.

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -1,11 +1,3 @@
----
-title: Intro to Anchor development
-objectives:
-- Use the Anchor framework to build a basic program
-- Describe the basic structure of an Anchor program
-- Explain how to implement basic account validation and security checks with Anchor
----
-
 # TL;DR
 
 - **Anchor** is a framework for building Solana programs

--- a/content/intro-to-cryptography.md
+++ b/content/intro-to-cryptography.md
@@ -1,12 +1,3 @@
----
-title: Cryptography and the Solana Network
-objectives:
-- Understand symmetric and asymmetric cryptography
-- Explain keypairs
-- Generate a new keypair
-- Load a keypair from an env file
----
-
 # TL;DR
 
 - A **keypair** is a matching pair of **public key** and **secret key**. 

--- a/content/intro-to-reading-data.md
+++ b/content/intro-to-reading-data.md
@@ -1,11 +1,3 @@
----
-title: Read Data From The Solana Network
-objectives:
-- Understand accounts and their addresses
-- Understand SOL and lamports
-- Use web3.js to connect to Solana and read an account balance
----
-
 ## TL;DR
 
 - **SOL** is the name of Solana’s native token. Each Sol is made from 1 billion **Lamports**. 

--- a/content/intro-to-writing-data.md
+++ b/content/intro-to-writing-data.md
@@ -1,13 +1,3 @@
----
-title: Write Data To The Solana Network
-objectives:
-- Explain transactions
-- Explain transaction fees
-- Use `@solana/web3.js` to send SOL
-- Use `@solana/web3.js` to sign transactions
-- Use Solana explorer to view transactions
----
-
 # TL;DR
 
 All modifications to on-chain data happen through **transactions**. Transactions are mostly a set of instructions that invoke Solana programs. Transactions are atomic, meaning they either succeed - if all the instructions have executed properly - or fail, as if the transaction hasn't been run at all. 

--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -1,13 +1,3 @@
----
-title: Local Program Development
-objectives:
-- Set up a local environment for Solana program development
-- Use basic Solana CLI commands
-- Run a local test validator
-- Use Rust and the Solana CLI to deploy a Solana program from your local development environment
-- Use the Solana CLI to view program logs
----
-
 # TL;DR
 
 - To get started with Solana locally, you’ll first need to install **Rust** and the **Solana CLI**

--- a/content/nfts-with-metaplex.md
+++ b/content/nfts-with-metaplex.md
@@ -1,12 +1,3 @@
----
-title: Create Solana NFTs With Metaplex
-objectives:
-- Explain NFTs and how they're represented on the Solana network
-- Explain the role of Metaplex in the Solana NFT ecosystem
-- Create and update NFTs using the Metaplex SDK
-- Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana
----
-
 # TL;DR
 
 - **Non-Fungible Tokens (NFTs)** are represented on Solana as SPL Tokens with an associated metadata account, 0 decimals, and a maximum supply of 1

--- a/content/oracles.md
+++ b/content/oracles.md
@@ -1,13 +1,3 @@
----
-title: Oracles and Oracle Networks
-objectives:
-- Explain why on-chain programs cannot readily access real-world data on their own
-- Explain how oracles solve the problem to accessing real-world data on-chain
-- Explain how incentivized oracle networks make data more trustworthy
-- Effectively weigh the tradeoffs between using various types of oracles
-- Use oracles from an on-chain program to access real-world data
----
-
 # TL;DR
 
 - Oracles are services that provide external data to a blockchain network

--- a/content/owner-checks.md
+++ b/content/owner-checks.md
@@ -1,12 +1,3 @@
----
-title: Owner Checks
-objectives:
-- Explain the security risks associated with not performing appropriate owner checks
-- Implement owner checks using long-form Rust
-- Use Anchor’s `Account<'info, T>` wrapper and an account type to automate owner checks
-- Use Anchor’s `#[account(owner = <expr>)]` constraint to explicitly define an external program that should own an account
----
-
 # TL;DR
 
 - Use **Owner Checks** to verify that accounts are owned by the expected program. Without appropriate owner checks, accounts owned by unexpected programs could be used in an instruction.

--- a/content/paging-ordering-filtering-data.md
+++ b/content/paging-ordering-filtering-data.md
@@ -1,14 +1,3 @@
----
-title: Page, Order, and Filter Program Data
-objectives:
-- Page, order, and filter accounts
-- Prefetch accounts without data
-- Determine where in an account’s buffer layout specific data is stored
-- Prefetch accounts with a subset of data that can be used to order accounts
-- Fetch only accounts whose data matches specific criteria
-- Fetch a subset of total accounts using `getMultipleAccounts`
----
-
 # TL;DR
 
 - This lesson delves into some functionality of the RPC calls that we used in the deserializing account data lesson

--- a/content/pda-sharing.md
+++ b/content/pda-sharing.md
@@ -1,11 +1,3 @@
----
-title: PDA Sharing
-objectives:
-- Explain the security risks associated with PDA sharing
-- Derive PDAs that have discrete authority domains
-- Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts
----
-
 # TL;DR
 
 - Using the same PDA for multiple authority domains opens your program up to the possibility of users accessing data and funds that don't belong to them

--- a/content/pda.md
+++ b/content/pda.md
@@ -1,13 +1,3 @@
----
-title: PDAs
-objectives:
-- Explain Program Derived Addresses (PDAs)
-- Explain various use cases of PDAs
-- Describe how PDAs are derived
-- Use PDA derivations to locate and retrieve data
----
-
-
 # TL;DR
 
 - A **Program Derived Address** (PDA) is derived from a **program ID** and an optional list of **seeds**

--- a/content/program-architecture.md
+++ b/content/program-architecture.md
@@ -1,12 +1,3 @@
----
-title: Program Architecture
-objectives:
-- Use Box and Zero Copy to work with large data on-chain
-- Make better PDA design decisions
-- Future-proof your programs
-- Deal with concurrency issues
----
-
 # TL;DR
 
 - If your data accounts are too large for the Stack, wrap them in `Box` to allocate them to the Heap

--- a/content/program-security.md
+++ b/content/program-security.md
@@ -1,14 +1,3 @@
----
-title: Create a Basic Program, Part 3 - Basic Security and Validation
-objectives:
-- Explain the importance of "thinking like an attacker"
-- Understand basic security practices
-- Perform owner checks
-- Perform signer checks
-- Validate accounts passed into the program
-- Perform basic data validation
----
-
 # TL;DR
 
 - **Thinking like an attacker** means asking "How do I break this?"

--- a/content/program-state-management.md
+++ b/content/program-state-management.md
@@ -1,13 +1,3 @@
----
-title: Create a Basic Program, Part 2 - State Management
-objectives:
-- Describe the process of creating a new account using a Program Derived Address (PDA)
-- Use seeds to derive a PDA
-- Use the space required by an account to calculate the amount of rent (in lamports) a user must allocate
-- Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account
-- Explain how to update the data stored on a new account
----
-
 # TL;DR
 
 - Program state is stored in other accounts rather than in the program itself

--- a/content/reinitialization-attacks.md
+++ b/content/reinitialization-attacks.md
@@ -1,11 +1,3 @@
----
-title: Reinitialization Attacks
-objectives:
-- Explain security risks associated with a reinitialization vulnerability
-- Use long-form Rust check if an account has already been initialized
-- Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account
----
-
 # TL;DR
 
 - Use an account discriminator or initialization flag to check whether an account has already been initialized to prevent an account from being reinitialized and overriding existing account data.

--- a/content/rust-macros.md
+++ b/content/rust-macros.md
@@ -1,11 +1,3 @@
----
-title: Rust Procedural Macros
-objectives:
-- Create and use **Procedural Macros** in Rust
-- Explain and work with a Rust Abstract Syntax Tree (AST)
-- Describe how procedural macros are used in the Anchor framework
----
-
 # TL;DR
 
 -   **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.

--- a/content/security-intro.md
+++ b/content/security-intro.md
@@ -1,9 +1,3 @@
----
-title: How to approach the Program Security module
-objectives:
-- understand how to approach the Program Security Module
----
-
 The goal of this module is to expose you to a wide variety of common security exploits that are unique to Solana development. We’ve heavily modeled this module off a public GitHub repository call Sealevel Attacks created by the great Armani Ferrante.
 
 You might be thinking: “didn’t we have a security lesson in module 3?” Yes, we most certainly did. We wanted to make sure that anyone deploying programs to Mainnet right out of the gates had at least a basic understanding of security. And if that’s you then hopefully the fundamental principles you learned in that lesson have led to you avoiding some common Solana exploits on your own.

--- a/content/serialize-instruction-data.md
+++ b/content/serialize-instruction-data.md
@@ -1,13 +1,3 @@
----
-title: Serialize Custom Instruction Data
-objectives:
-- Explain the contents of a transaction
-- Explain transaction instructions
-- Explain the basics of Solana's runtime optimizations
-- Explain Borsh
-- Use Borsh to serialize program data
----
-
 # TL;DR
 
 - Transactions are made up of an array of instructions, a single transaction can have any number of instructions in it, each targeting its own program. When a transaction is submitted, the Solana runtime will process its instructions in order and atomically, meaning that if any of the instructions fail for any reason, the entire transaction will fail to be processed.

--- a/content/signer-auth.md
+++ b/content/signer-auth.md
@@ -1,12 +1,3 @@
----
-title: Signer Authorization
-objectives:
-- Explain the security risks associated with not performing appropriate signer checks
-- Implement signer checks using long-form Rust
-- Implement signer checks using Anchor’s `Signer` type
-- Implement signer checks using Anchor’s `#[account(signer)]` constraint
----
-
 # TL;DR
 
 - Use **Signer Checks** to verify that specific accounts have signed a transaction. Without appropriate signer checks, accounts may be able to execute instructions they shouldn’t be authorized to perform.

--- a/content/solana-pay.md
+++ b/content/solana-pay.md
@@ -1,11 +1,3 @@
----
-title: Solana Pay
-objectives:
-- Use the Solana Pay specification to build payment requests and initiate transactions using URLs encoded as QR codes
-- Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests
-- Partially sign transactions and implement transaction gating based on certain conditions
----
-
 # TL;DR
 
 -   **Solana Pay** is a specification for encoding Solana transaction requests within URLs, enabling standardized transaction requests across different Solana apps and wallets

--- a/content/token-program.md
+++ b/content/token-program.md
@@ -1,13 +1,3 @@
----
-title: Create Tokens With The Token Program
-objectives:
-- Create token mints
-- Create token accounts
-- Mint tokens
-- Transfer tokens
-- Burn tokens
----
-
 # TL;DR
 
 - **SPL-Tokens** represent all non-native tokens on the Solana network. Both fungible and non-fungible tokens (NFTs) on Solana are SPL-Tokens

--- a/content/token-swap.md
+++ b/content/token-swap.md
@@ -1,12 +1,3 @@
----
-title: Swap Tokens With The Token Swap Program
-objectives:
-- Create a token swap pool
-- Deposit liquidity
-- Withdraw liquidity
-- Swap tokens
----
-
 # TL;DR
 
 - The **Token Swap Program** is an SPL contract deployed to Devnet available for testing and experimentation by developers and protocols. For production use cases, use your own deployment or one regularly maintained by a reputable service.

--- a/content/type-cosplay.md
+++ b/content/type-cosplay.md
@@ -1,12 +1,3 @@
----
-title: Type Cosplay
-objectives:
-- Explain the security risks associated with not checking account types
-- Implement an account type discriminator using long-form Rust
-- Use Anchor's `init` constraint to initialize accounts
-- Use Anchor's `Account` type for account validation
----
-
 # TL;DR
 
 - Use discriminators to distinguish between different account types

--- a/content/versioned-transaction.md
+++ b/content/versioned-transaction.md
@@ -1,12 +1,3 @@
----
-title: Versioned Transactions and Lookup Tables
-objectives:
-- Create versioned transactions
-- Create lookup tables
-- Extend lookup tables
-- Use lookup tables with versioned transactions
----
-
 # TL;DR
 
 -   **Versioned Transactions** refers to a way to support both legacy versions and newer versions of transaction formats. The original transaction format is "legacy" and new transaction versions start at version 0. Versioned transactions were implemented in order to support the use of Address Lookup Tables (also called lookup tables or LUTs).

--- a/content/vrf.md
+++ b/content/vrf.md
@@ -1,11 +1,3 @@
----
-title: Verifiable Randomness Functions
-objectives:
-- Explain the limitations of generating random numbers on-chain
-- Explain how Verifiable Randomness works
-- Use Switchboard's VRF oracle queue to generate and consume randomness from an on-chain program
----
-
 # TL;DR
 
 - Attempts at generating randomness withing your program are likely to be guessable by users given there's no true randomness on-chain.

--- a/course-structure.json
+++ b/course-structure.json
@@ -14,7 +14,7 @@
                 ],
                 "number": 1,
                 "hidden": false,
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de la guía del curso",
                         "objectives": [
@@ -39,7 +39,8 @@
                     "Load a keypair from an env file"
                 ],
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "translations": {}
             },
             {
                 "title": "Read data from the network",
@@ -51,7 +52,7 @@
                 ],
                 "number": 2,
                 "hidden": false,
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Lea los datos de los objetivos de la red Solana",
                         "objectives": [
@@ -79,7 +80,7 @@
                 ],
                 "number": 3,
                 "hidden": false,
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Escribir datos a los objetivos de la red Solana",
                         "objectives": [
@@ -106,7 +107,7 @@
                     "Set Phantom wallet to [Devnet](https://api.devnet.solana.com/)",
                     "Use wallet-adapter to have users sign transactions"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Interactúa con los objetivos de Wallets",
                         "objectives": [
@@ -130,7 +131,7 @@
                     "Explain Borsh",
                     "Use Borsh to serialize program data"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Serializar los objetivos de los datos de instrucción personalizados",
                         "objectives": [
@@ -154,7 +155,7 @@
                     "Fetch a program’s accounts",
                     "Use Borsh to deserialize custom data"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Deserializar los objetivos de los datos de la cuenta personalizada",
                         "objectives": [
@@ -179,7 +180,7 @@
                     "Fetch only accounts whose data matches specific criteria",
                     "Fetch a subset of total accounts using `getMultipleAccounts`"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Page, Order, and Filter Program Data",
                         "objectives": [
@@ -211,7 +212,7 @@
                     "Transfer tokens",
                     "Burn tokens"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear Tokens con los objetivos del Programa Token",
                         "objectives": [
@@ -235,7 +236,7 @@
                     "Withdraw liquidity",
                     "Swap tokens"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Tokens de intercambio con los objetivos del Programa de intercambio de tokens",
                         "objectives": [
@@ -258,7 +259,7 @@
                     "Create and update NFTs using the Metaplex SDK",
                     "Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear NFT de Solana con objetivos Metaplex",
                         "objectives": [
@@ -289,7 +290,7 @@
                     "Build and deploy a basic Solana program",
                     "Submit a transaction to invoke our “Hello, world!” program"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de Hello World",
                         "objectives": [
@@ -317,7 +318,7 @@
                     "Execute different program logic for different types of instructions",
                     "Explain the structure of a smart contract on Solana"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear un Programa Básico, Parte 1 - Manejar los objetivos de los Datos de Instrucción",
                         "objectives": [
@@ -344,7 +345,7 @@
                     "Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account",
                     "Explain how to update the data stored on a new account"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear un Programa Básico, Parte 2 - Objetivos de la Administración del Estado",
                         "objectives": [
@@ -370,7 +371,7 @@
                     "Validate accounts passed into the program",
                     "Perform basic data validation"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear un Programa Básico, Parte 3 - Objetivos Básicos de Seguridad y Validación",
                         "objectives": [
@@ -402,7 +403,7 @@
                     "Use Rust and the Solana CLI to deploy a Solana program from your local development environment",
                     "Use the Solana CLI to view program logs"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "objectives": [
                             "Crear un entorno local para el desarrollo del programa Solana",
@@ -425,7 +426,7 @@
                     "Describe how PDAs are derived",
                     "Use PDA derivations to locate and retrieve data"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "PDAS",
                         "objectives": [
@@ -448,7 +449,7 @@
                     "Explain how a program provides a signature for a PDA",
                     "Avoid common pitfalls and troubleshoot common errors associated with CPIs"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de las Invocaciones del Programa Cruzado",
                         "objectives": [
@@ -463,8 +464,10 @@
             {
                 "title": "Program Testing - COMING SOON",
                 "slug": "",
+                "number": 4,
                 "hidden": true,
-                "number": 4
+                "objectives": [],
+                "translations": {}
             }
         ]
     },
@@ -482,7 +485,7 @@
                     "Describe the basic structure of an Anchor program",
                     "Explain how to implement basic account validation and security checks with Anchor"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Introducción a los objetivos de desarrollo de Anchor",
                         "objectives": [
@@ -506,7 +509,7 @@
                     "Use Anchor to fetch accounts",
                     "Set up a frontend to invoke instructions using Anchor and an IDL"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Introducción a los objetivos de desarrollo de Anchor del lado del cliente",
                         "objectives": [
@@ -531,7 +534,7 @@
                     "Use the `realloc` constraint to reallocate space on an existing account",
                     "Use the `close` constraint to close an existing account"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Anclar los PDA y los objetivos de las cuentas",
                         "objectives": [
@@ -554,7 +557,7 @@
                     "Use `invoke` and `invoke_signed` to make CPIs where CPI helper functions are unavailable",
                     "Create and return custom Anchor errors"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Anclar los objetivos de IPC y Errores.",
                         "objectives": [
@@ -583,7 +586,7 @@
                     "Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled",
                     "Create an admin-only instruction to set up a program account that can be used to store program configuration values"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Variables de entorno en los objetivos de los Programas Solana",
                         "objectives": [
@@ -605,7 +608,7 @@
                     "Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests",
                     "Partially sign transactions and implement transaction gating based on certain conditions"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Crear Tokens con los objetivos del Programa Token",
                         "objectives": [
@@ -629,7 +632,7 @@
                     "Extend lookup tables",
                     "Use lookup tables with versioned transactions"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de Transacciones Versionadas y Tablas de Búsqueda",
                         "objectives": [
@@ -651,7 +654,7 @@
                     "Explain and work with a Rust Abstract Syntax Tree (AST)",
                     "Describe how procedural macros are used in the Anchor framework"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Rust Procedural Macros",
                         "objectives": [
@@ -676,7 +679,7 @@
                 "objectives": [
                     "understand how to approach the Program Security Module"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Cómo abordar los objetivos del módulo de seguridad del programa",
                         "objectives": [
@@ -696,7 +699,7 @@
                     "Implement signer checks using Anchor’s `Signer` type",
                     "Implement signer checks using Anchor’s `#[account(signer)]` constraint"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de la autorización del firmante",
                         "objectives": [
@@ -719,7 +722,7 @@
                     "Use Anchor’s `Account<'info, T>` wrapper and an account type to automate owner checks",
                     "Use Anchor’s `#[account(owner = <expr>)]` constraint to explicitly define an external program that should own an account"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "El propietario comprueba los objetivos",
                         "objectives": [
@@ -741,7 +744,7 @@
                     "Implement data validation checks using long-form Rust",
                     "Implement data validation checks using Anchor constraints"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de coincidencia de datos de cuenta",
                         "objectives": [
@@ -762,7 +765,7 @@
                     "Use long-form Rust check if an account has already been initialized",
                     "Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Reinicialización Ataques",
                         "objectives": [
@@ -783,7 +786,7 @@
                     "Implement a check for duplicate mutable accounts using long-form Rust",
                     "Implement a check for duplicate mutable accounts using Anchor constraints"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de las cuentas mutables duplicadas",
                         "objectives": [
@@ -805,7 +808,7 @@
                     "Use Anchor's `init` constraint to initialize accounts",
                     "Use Anchor's `Account` type for account validation"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Tipo Objetivos del cosplay",
                         "objectives": [
@@ -827,7 +830,7 @@
                     "Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another",
                     "Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos arbitrarios del IPC",
                         "objectives": [
@@ -848,7 +851,7 @@
                     "Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump",
                     "Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "objectives": [
                             "Explicar las vulnerabilidades asociadas con el uso de PDA derivados sin el bache canónico",
@@ -868,7 +871,7 @@
                     "Close program accounts safely and securely using native Rust",
                     "Close program accounts safely and securely using the Anchor `close` constraint"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "Objetivos de las cuentas de cierre y los ataques de reactivación",
                         "objectives": [
@@ -889,7 +892,7 @@
                     "Derive PDAs that have discrete authority domains",
                     "Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts"
                 ],
-                "transations": {
+                "translations": {
                     "es": {
                         "title": "PDA Sharing",
                         "objectives": [

--- a/course-structure.json
+++ b/course-structure.json
@@ -13,7 +13,15 @@
                     "know how to get the most from this course"
                 ],
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de la guía del curso",
+                        "objectives": [
+                            "explicar cómo está estructurado este curso de Solana"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -27,8 +35,8 @@
                 "objectives": [
                     "Understand symmetric and asymmetric cryptography",
                     "Explain keypairs",
-                    "Use `@solana/web3.js` to generate a new keypair",
-                    "Use `@solana-developers/node-helpers` to load a keypair from an env file"
+                    "Generate a new keypair",
+                    "Load a keypair from an env file"
                 ],
                 "number": 1,
                 "hidden": false
@@ -37,16 +45,27 @@
                 "title": "Read data from the network",
                 "slug": "intro-to-reading-data",
                 "objectives": [
-                    "Understand accounts",
+                    "Understand accounts and their addresses",
                     "Understand SOL and lamports",
-                    "Understand the JSON RPC API",
-                    "Understand web3.js",
-                    "Install web3.js",
-                    "Use web3.js to create a connection to a Solana node",
-                    "Use web3.js to read data from the blockchain (balance, account info, etc.)"
+                    "Use web3.js to connect to Solana and read an account balance"
                 ],
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "transations": {
+                    "es": {
+                        "title": "Lea los datos de los objetivos de la red Solana",
+                        "objectives": [
+                            "Explicar cuentas",
+                            "Explicar SOL y lamports",
+                            "Explicar claves públicas",
+                            "Explicar la API de JSON RPC",
+                            "Explicar web3.js",
+                            "Instalar web3.js",
+                            "Utilice web3.js para crear una conexión a un nodo de Solana",
+                            "Utilice web3.js para leer datos de la cadena de bloques (saldo, información de la cuenta, etc.)"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Write data to the network",
@@ -59,31 +78,120 @@
                     "Use Solana explorer to view transactions"
                 ],
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "transations": {
+                    "es": {
+                        "title": "Escribir datos a los objetivos de la red Solana",
+                        "objectives": [
+                            "Explicar el par de teclas",
+                            "Utilizar `@solana/web3.js` para generar un par de claves",
+                            "Usar `@solana/web3.js` para crear un par de claves usando una clave secreta",
+                            "Explicar transacciones",
+                            "Explicar las tarifas de transacción",
+                            "Usar `@solana/web3.js` para enviar sol",
+                            "Utilizar `@solana/web3.js` para firmar transacciones",
+                            "Utilice Solana Explorer para ver las transacciones"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Interact with wallets",
                 "slug": "interact-with-wallets",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain wallets",
+                    "Install Phantom extension",
+                    "Set Phantom wallet to [Devnet](https://api.devnet.solana.com/)",
+                    "Use wallet-adapter to have users sign transactions"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Interactúa con los objetivos de Wallets",
+                        "objectives": [
+                            "Explicar monederos",
+                            "Instalar extensión fantasma",
+                            "Establecer cartera fantasma en [Devnet](https://api.devnet.solana.com/)",
+                            "Utilice el adaptador de billetera para que los usuarios firmen transacciones"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Serialize program data",
                 "slug": "serialize-instruction-data",
                 "number": 5,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the contents of a transaction",
+                    "Explain transaction instructions",
+                    "Explain the basics of Solana's runtime optimizations",
+                    "Explain Borsh",
+                    "Use Borsh to serialize program data"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Serializar los objetivos de los datos de instrucción personalizados",
+                        "objectives": [
+                            "Explicar el contenido de una transacción",
+                            "Explicar las instrucciones de transacción",
+                            "Explicar los conceptos básicos de las optimizaciones de tiempo de ejecución de Solana",
+                            "Explicar Borsh",
+                            "Utilice Borsh para serializar datos de instrucciones personalizadas"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Deserialize program data",
                 "slug": "deserialize-custom-data",
                 "number": 6,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain Program Derived Accounts",
+                    "Derive PDAs given specific seeds",
+                    "Fetch a program’s accounts",
+                    "Use Borsh to deserialize custom data"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Deserializar los objetivos de los datos de la cuenta personalizada",
+                        "objectives": [
+                            "Explicar cuentas derivadas del programa",
+                            "Derivar PDAs dadas semillas específicas",
+                            "Obtener las cuentas de un programa",
+                            "Usar Borsh para deserializar datos personalizados"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Page, Order, and Filter program data",
                 "slug": "paging-ordering-filtering-data",
                 "number": 7,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Page, order, and filter accounts",
+                    "Prefetch accounts without data",
+                    "Determine where in an account’s buffer layout specific data is stored",
+                    "Prefetch accounts with a subset of data that can be used to order accounts",
+                    "Fetch only accounts whose data matches specific criteria",
+                    "Fetch a subset of total accounts using `getMultipleAccounts`"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Page, Order, and Filter Program Data",
+                        "objectives": [
+                            "Páginas, pedidos y filtros de cuentas",
+                            "Obtener cuentas sin datos",
+                            "Determinar dónde se almacenan los datos específicos en el diseño del búfer de una cuenta",
+                            "Obtener cuentas con un subconjunto de datos que se pueden utilizar para ordenar cuentas",
+                            "Obtener solo cuentas cuyos datos coincidan con criterios específicos",
+                            "Obtener un subconjunto de cuentas totales usando `getMultipleAccounts`"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -95,19 +203,72 @@
                 "title": "Create tokens with the Token Program",
                 "slug": "token-program",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Create token mints",
+                    "Create token accounts",
+                    "Mint tokens",
+                    "Transfer tokens",
+                    "Burn tokens"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear Tokens con los objetivos del Programa Token",
+                        "objectives": [
+                            "Crear fichas de menta",
+                            "Crear cuentas de token",
+                            "Tokens de menta",
+                            "Transferir tokens",
+                            "Quemar tokens"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Swap tokens with the Token Swap Program",
                 "slug": "token-swap",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Create a token swap pool",
+                    "Deposit liquidity",
+                    "Withdraw liquidity",
+                    "Swap tokens"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Tokens de intercambio con los objetivos del Programa de intercambio de tokens",
+                        "objectives": [
+                            "Crear un grupo de intercambio de tokens",
+                            "Liquidez de depósitos",
+                            "Retirar liquidez",
+                            "Tokens de swap"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Create Solana NFTs With Metaplex",
                 "slug": "nfts-with-metaplex",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain NFTs and how they're represented on the Solana network",
+                    "Explain the role of Metaplex in the Solana NFT ecosystem",
+                    "Create and update NFTs using the Metaplex SDK",
+                    "Explain the basic functionality of the Token Metadata program, Candy Machine program, and Sugar CLI as tools that assist in creating and distributing NFTs on Solana"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear NFT de Solana con objetivos Metaplex",
+                        "objectives": [
+                            "Explicar los NFT y cómo están representados en la red de Solana",
+                            "Explicar el papel de Metaplex en el ecosistema NFT de Solana",
+                            "Crear y actualizar NFTs usando el SDK Metaplex",
+                            "Explicar la funcionalidad básica del programa Token Metadata, el programa Candy Machine y Sugar CLI como herramientas que ayudan a crear y distribuir NFT en Solana"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -119,25 +280,109 @@
                 "title": "Hello World",
                 "slug": "hello-world-program",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use the Rust module system",
+                    "Define a function in Rust",
+                    "Explain the `Result` type",
+                    "Explain the entry point to a Solana program",
+                    "Build and deploy a basic Solana program",
+                    "Submit a transaction to invoke our “Hello, world!” program"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de Hello World",
+                        "objectives": [
+                            "Utilice el sistema del módulo Rust",
+                            "Definir una función en Rust",
+                            "Explicar el `Result` tipo",
+                            "Explicar el punto de entrada a un programa de Solana",
+                            "Construir e implementar un programa básico de Solana",
+                            "Envíe una transacción para invocar nuestro programa \"¡Hola, mundo!\""
+                        ]
+                    }
+                }
             },
             {
                 "title": "Handle Instruction Data",
                 "slug": "deserialize-instruction-data",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Assign mutable and immutable variables in Rust",
+                    "Create and use Rust structs and enums",
+                    "Use Rust match statements",
+                    "Add implementations to Rust types",
+                    "Deserialize instruction data into Rust data types",
+                    "Execute different program logic for different types of instructions",
+                    "Explain the structure of a smart contract on Solana"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear un Programa Básico, Parte 1 - Manejar los objetivos de los Datos de Instrucción",
+                        "objectives": [
+                            "Asignar variables mutables e inmutables en Rust",
+                            "Crear y usar estructuras y enumeraciones de óxido",
+                            "Usar declaraciones de coincidencia de óxido",
+                            "Añadir implementaciones a los tipos de óxido",
+                            "Deserializar los datos de instrucción en tipos de datos de óxido",
+                            "Ejecutar diferentes lógicas de programa para diferentes tipos de instrucciones",
+                            "Explicar la estructura de un contrato inteligente en Solana"
+                        ]
+                    }
+                }
             },
             {
                 "title": "State Management",
                 "slug": "program-state-management",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Describe the process of creating a new account using a Program Derived Address (PDA)",
+                    "Use seeds to derive a PDA",
+                    "Use the space required by an account to calculate the amount of rent (in lamports) a user must allocate",
+                    "Use a Cross Program Invocation (CPI) to initialize an account with a PDA as the address of the new account",
+                    "Explain how to update the data stored on a new account"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear un Programa Básico, Parte 2 - Objetivos de la Administración del Estado",
+                        "objectives": [
+                            "Describir el proceso de creación de una nueva cuenta utilizando una dirección derivada del programa (PDA)",
+                            "Usar semillas para derivar un PDA",
+                            "Utilice el espacio requerido por una cuenta para calcular la cantidad de alquiler (en lamports) que un usuario debe asignar",
+                            "Utilice una Invocación de programa cruzado (CPI) para inicializar una cuenta con un PDA como la dirección de la nueva cuenta",
+                            "Explicar cómo actualizar los datos almacenados en una nueva cuenta"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Basic Security and Validation",
                 "slug": "program-security",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the importance of \"thinking like an attacker\"",
+                    "Understand basic security practices",
+                    "Perform owner checks",
+                    "Perform signer checks",
+                    "Validate accounts passed into the program",
+                    "Perform basic data validation"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear un Programa Básico, Parte 3 - Objetivos Básicos de Seguridad y Validación",
+                        "objectives": [
+                            "Explicar la importancia de \"pensar como un atacante\"",
+                            "Comprender las prácticas básicas de seguridad",
+                            "Realizar comprobaciones del propietario",
+                            "Realizar comprobaciones del firmante",
+                            "Validar cuentas pasadas al programa",
+                            "Realizar validación de datos básicos"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -149,19 +394,71 @@
                 "title": "Local Program Development",
                 "slug": "local-setup",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Set up a local environment for Solana program development",
+                    "Use basic Solana CLI commands",
+                    "Run a local test validator",
+                    "Use Rust and the Solana CLI to deploy a Solana program from your local development environment",
+                    "Use the Solana CLI to view program logs"
+                ],
+                "transations": {
+                    "es": {
+                        "objectives": [
+                            "Crear un entorno local para el desarrollo del programa Solana",
+                            "Usar comandos CLI básicos de Solana",
+                            "Ejecutar un validador de prueba local",
+                            "Utilice Rust y Solana CLI para implementar un programa Solana desde su entorno de desarrollo local",
+                            "Utilice la CLI de Solana para ver los registros del programa"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Program Derived Addresses",
                 "slug": "pda",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain Program Derived Addresses (PDAs)",
+                    "Explain various use cases of PDAs",
+                    "Describe how PDAs are derived",
+                    "Use PDA derivations to locate and retrieve data"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "PDAS",
+                        "objectives": [
+                            "Explicar las direcciones derivadas del programa (PDA)",
+                            "Explicar varios casos de uso de PDA",
+                            "Describir cómo se derivan los PDA",
+                            "Utilice las derivaciones de PDA para localizar y recuperar datos"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Cross Program Invocations",
                 "slug": "cpi",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain Cross-Program Invocations (CPIs)",
+                    "Describe how to construct and use CPIs",
+                    "Explain how a program provides a signature for a PDA",
+                    "Avoid common pitfalls and troubleshoot common errors associated with CPIs"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de las Invocaciones del Programa Cruzado",
+                        "objectives": [
+                            "Explicar las invocaciones de programas cruzados (CPI)",
+                            "Describir cómo construir y usar los IPC",
+                            "Explicar cómo un programa proporciona una firma para un PDA",
+                            "Evite las trampas comunes y solucione los errores comunes asociados con los IPC"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Program Testing - COMING SOON",
@@ -179,25 +476,95 @@
                 "title": "Intro to Anchor development",
                 "slug": "intro-to-anchor",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use the Anchor framework to build a basic program",
+                    "Describe the basic structure of an Anchor program",
+                    "Explain how to implement basic account validation and security checks with Anchor"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Introducción a los objetivos de desarrollo de Anchor",
+                        "objectives": [
+                            "Usar el framework de Anchor para construir un programa básico",
+                            "Describir la estructura básica de un programa de anclaje",
+                            "Explicar cómo implementar la validación básica de la cuenta y los controles de seguridad con Anchor"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Intro to client-side Anchor development",
                 "slug": "intro-to-anchor-frontend",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use an IDL to interact with a Solana program from the client",
+                    "Explain an Anchor `Provider` object",
+                    "Explain an Anchor `Program` object",
+                    "Use the Anchor `MethodsBuilder` to build instructions and transactions",
+                    "Use Anchor to fetch accounts",
+                    "Set up a frontend to invoke instructions using Anchor and an IDL"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Introducción a los objetivos de desarrollo de Anchor del lado del cliente",
+                        "objectives": [
+                            "Utilice un IDL para interactuar con un programa Solana del cliente",
+                            "Explicar un `Provider` objeto de anclaje",
+                            "Explicar un `Program` objeto de anclaje",
+                            "Utilice el Ancla `MethodsBuilder` para crear instrucciones y transacciones",
+                            "Usar Anchor para recuperar cuentas",
+                            "Configurar un frontend para invocar instrucciones usando Anchor y un IDL"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Anchor PDAs and accounts",
                 "slug": "anchor-pdas",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use the `seeds` and `bump` constraints to work with PDA accounts in Anchor",
+                    "Enable and use the `init_if_needed` constraint",
+                    "Use the `realloc` constraint to reallocate space on an existing account",
+                    "Use the `close` constraint to close an existing account"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Anclar los PDA y los objetivos de las cuentas",
+                        "objectives": [
+                            "Utilice las `bump` restricciones `seeds` y para trabajar con cuentas PDA en Anchor",
+                            "Habilitar y usar la `init_if_needed` restricción",
+                            "Utilice la `realloc` restricción para reasignar espacio en una cuenta existente",
+                            "Utilice la `close` restricción para cerrar una cuenta existente"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Anchor CPIs and errors",
                 "slug": "anchor-cpi",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Make Cross Program Invocations (CPIs) from an Anchor program",
+                    "Use the `cpi` feature to generate helper functions for invoking instructions on existing Anchor programs",
+                    "Use `invoke` and `invoke_signed` to make CPIs where CPI helper functions are unavailable",
+                    "Create and return custom Anchor errors"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Anclar los objetivos de IPC y Errores.",
+                        "objectives": [
+                            "Haga Invocaciones de Programas Cruzados (CPI) de un programa Anchor",
+                            "Utilice la `cpi` función para generar funciones auxiliares para invocar instrucciones en los programas de Anchor existentes",
+                            "Usar `invoke` y `invoke_signed` hacer CPI donde las funciones de ayuda de CPI no están disponibles",
+                            "Crear y devolver errores de anclaje personalizados"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -209,25 +576,91 @@
                 "title": "Environment variables in Solana programs",
                 "slug": "env-variables",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Define program features in the `Cargo.toml` file",
+                    "Use the Rust `cfg` attribute to conditionally compile code based on which features are or are not enabled",
+                    "Use the Rust `cfg!` macro to conditionally compile code based on which features are or are not enabled",
+                    "Create an admin-only instruction to set up a program account that can be used to store program configuration values"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Variables de entorno en los objetivos de los Programas Solana",
+                        "objectives": [
+                            "Definir características del programa en el `Cargo.toml` archivo",
+                            "Utilice el `cfg` atributo Rust para compilar código condicionalmente en función de qué características están o no habilitadas",
+                            "Utilice la `cfg!` macro Rust para compilar código condicionalmente en función de qué características están o no habilitadas",
+                            "Crear una instrucción de solo administrador para configurar una cuenta de programa que se pueda usar para almacenar valores de configuración del programa"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Solana Pay",
                 "slug": "solana-pay",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use the Solana Pay specification to build payment requests and initiate transactions using URLs encoded as QR codes",
+                    "Use the `@solana/pay` library to help with the creation of Solana Pay transaction requests",
+                    "Partially sign transactions and implement transaction gating based on certain conditions"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Crear Tokens con los objetivos del Programa Token",
+                        "objectives": [
+                            "Crear fichas de menta",
+                            "Crear cuentas de token",
+                            "Tokens de menta",
+                            "Transferir tokens",
+                            "Quemar tokens"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Versioned transactions and lookup tables",
                 "slug": "versioned-transaction",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Create versioned transactions",
+                    "Create lookup tables",
+                    "Extend lookup tables",
+                    "Use lookup tables with versioned transactions"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de Transacciones Versionadas y Tablas de Búsqueda",
+                        "objectives": [
+                            "Crear transacciones versionadas",
+                            "Crear tablas de búsqueda",
+                            "Extender tablas de búsqueda",
+                            "Usar tablas de búsqueda con transacciones versionadas"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Rust procedural macros",
                 "slug": "rust-macros",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Create and use **Procedural Macros** in Rust",
+                    "Explain and work with a Rust Abstract Syntax Tree (AST)",
+                    "Describe how procedural macros are used in the Anchor framework"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Rust Procedural Macros",
+                        "objectives": [
+                            "Create and use **Procedural Macros** in Rust",
+                            "Explain and work with a Rust Abstract Syntax Tree (AST)",
+                            "Describe how procedural macros are used in the Anchor framework"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -239,67 +672,233 @@
                 "title": "How to approach the Program Security module",
                 "slug": "security-intro",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "understand how to approach the Program Security Module"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Cómo abordar los objetivos del módulo de seguridad del programa",
+                        "objectives": [
+                            "entender cómo abordar el Módulo de seguridad del programa"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Signer authorization",
                 "slug": "signer-auth",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with not performing appropriate signer checks",
+                    "Implement signer checks using long-form Rust",
+                    "Implement signer checks using Anchor’s `Signer` type",
+                    "Implement signer checks using Anchor’s `#[account(signer)]` constraint"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de la autorización del firmante",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del firmante",
+                            "Implementar comprobaciones de firmantes utilizando Rust de formato largo",
+                            "Implementar comprobaciones de firmantes utilizando el `Signer` tipo de Anchor",
+                            "Implementar comprobaciones de firmantes utilizando la `#[account(signer)]` restricción de Anchor"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Owner checks",
                 "slug": "owner-checks",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with not performing appropriate owner checks",
+                    "Implement owner checks using long-form Rust",
+                    "Use Anchor’s `Account<'info, T>` wrapper and an account type to automate owner checks",
+                    "Use Anchor’s `#[account(owner = <expr>)]` constraint to explicitly define an external program that should own an account"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "El propietario comprueba los objetivos",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con no realizar las comprobaciones apropiadas del propietario",
+                            "Implementar comprobaciones de propietario usando Rust de formato largo",
+                            "Utilice el `Account<'info, T>` envoltorio de Anchor y un tipo de cuenta para automatizar los cheques de propietario",
+                            "Utilice la `#[account(owner = <expr>)]` restricción de Anchor para definir explícitamente un programa externo que debería poseer una cuenta."
+                        ]
+                    }
+                }
             },
             {
                 "title": "Account data matching",
                 "slug": "account-data-matching",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with missing data validation checks",
+                    "Implement data validation checks using long-form Rust",
+                    "Implement data validation checks using Anchor constraints"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de coincidencia de datos de cuenta",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con la falta de comprobaciones de validación de datos",
+                            "Implementar comprobaciones de validación de datos utilizando Rust de formato largo",
+                            "Implementar comprobaciones de validación de datos utilizando restricciones de anclaje"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Reinitialization attacks",
                 "slug": "reinitialization-attacks",
                 "number": 5,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain security risks associated with a reinitialization vulnerability",
+                    "Use long-form Rust check if an account has already been initialized",
+                    "Using Anchor’s `init` constraint to initialize accounts, which automatically sets an account discriminator that is checked to prevent the reinitialization of an account"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Reinicialización Ataques",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con una vulnerabilidad de reinicialización",
+                            "Utilice la comprobación de óxido de formato largo si una cuenta ya se ha inicializado",
+                            "Usar la `init` restricción de Anchor para inicializar cuentas, que establece automáticamente un discriminador de cuenta que se comprueba para evitar la reinicialización de una cuenta"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Duplicate mutable accounts",
                 "slug": "duplicate-mutable-accounts",
                 "number": 6,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with instructions that require two mutable accounts of the same type and how to avoid them",
+                    "Implement a check for duplicate mutable accounts using long-form Rust",
+                    "Implement a check for duplicate mutable accounts using Anchor constraints"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de las cuentas mutables duplicadas",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con las instrucciones que requieren dos cuentas mutables del mismo tipo y cómo evitarlos",
+                            "Implementar una verificación de cuentas mutables duplicadas utilizando Rust de formato largo",
+                            "Implementar una verificación de cuentas mutables duplicadas utilizando las restricciones de Anchor"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Type cosplay",
                 "slug": "type-cosplay",
                 "number": 7,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with not checking account types",
+                    "Implement an account type discriminator using long-form Rust",
+                    "Use Anchor's `init` constraint to initialize accounts",
+                    "Use Anchor's `Account` type for account validation"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Tipo Objetivos del cosplay",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con no verificar los tipos de cuenta",
+                            "Implementar un discriminador de tipo de cuenta usando Rust de formato largo",
+                            "Utilice la `init` restricción de Anchor para inicializar cuentas",
+                            "Usar el `Account` tipo de Ancla para la validación de la cuenta"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Arbitrary CPIs",
                 "slug": "arbitrary-cpi",
                 "number": 8,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with invoking a CPI to an unknown program",
+                    "Showcase how Anchor’s CPI module prevents this from happening when making a CPI from one Anchor program to another",
+                    "Safely and securely make a CPI from an Anchor program to an arbitrary non-anchor program"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos arbitrarios del IPC",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con la invocación de un IPC a un programa desconocido",
+                            "Muestre cómo el módulo CPI de Anchor evita que esto suceda al realizar un CPI de un programa de Anchor a otro",
+                            "Hacer de forma segura un CPI de un programa de anclaje a un programa arbitrario que no sea de anclaje"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Bump seed canonicalization",
                 "slug": "bump-seed-canonicalization",
                 "number": 9,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the vulnerabilities associated with using PDAs derived without the canonical bump",
+                    "Initialize a PDA using Anchor’s `seeds` and `bump` constraints to automatically use the canonical bump",
+                    "Use Anchor's `seeds` and `bump` constraints to ensure the canonical bump is always used in future instructions when deriving a PDA"
+                ],
+                "transations": {
+                    "es": {
+                        "objectives": [
+                            "Explicar las vulnerabilidades asociadas con el uso de PDA derivados sin el bache canónico",
+                            "Inicializar un PDA usando Anchor 's `seeds` y `bump` restricciones para usar automáticamente el bache canónico",
+                            "Use Anchor 's `seeds` y `bump` restricciones para asegurarse de que la protuberancia canónica siempre se use en futuras instrucciones al derivar un PDA"
+                        ]
+                    }
+                }
             },
             {
                 "title": "Closing accounts and revival attacks",
                 "slug": "closing-accounts",
                 "number": 10,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the various security vulnerabilities associated with closing program accounts incorrectly",
+                    "Close program accounts safely and securely using native Rust",
+                    "Close program accounts safely and securely using the Anchor `close` constraint"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "Objetivos de las cuentas de cierre y los ataques de reactivación",
+                        "objectives": [
+                            "Explicar las diversas vulnerabilidades de seguridad asociadas con el cierre incorrecto de las cuentas del programa",
+                            "Cierre las cuentas del programa de forma segura con Rust nativo",
+                            "Cierre las cuentas del programa de forma segura utilizando la `close` restricción Anchor"
+                        ]
+                    }
+                }
             },
             {
                 "title": "PDA sharing",
                 "slug": "pda-sharing",
                 "number": 11,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the security risks associated with PDA sharing",
+                    "Derive PDAs that have discrete authority domains",
+                    "Use Anchor’s `seeds` and `bump` constraints to validate PDA accounts"
+                ],
+                "transations": {
+                    "es": {
+                        "title": "PDA Sharing",
+                        "objectives": [
+                            "Explicar los riesgos de seguridad asociados con el uso compartido de PDA",
+                            "Derivar PDA que tienen dominios de autoridad discretos",
+                            "Usar Anchor 's `seeds` y `bump` restricciones para validar cuentas PDA"
+                        ]
+                    }
+                }
             }
         ]
     },
@@ -311,25 +910,49 @@
                 "title": "Program architecture",
                 "slug": "program-architecture",
                 "number": 1,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Use Box and Zero Copy to work with large data on-chain",
+                    "Make better PDA design decisions",
+                    "Future-proof your programs",
+                    "Deal with concurrency issues"
+                ]
             },
             {
                 "title": "Oracles and oracle networks",
                 "slug": "oracles",
                 "number": 2,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain why on-chain programs cannot readily access real-world data on their own",
+                    "Explain how oracles solve the problem to accessing real-world data on-chain",
+                    "Explain how incentivized oracle networks make data more trustworthy",
+                    "Effectively weigh the tradeoffs between using various types of oracles",
+                    "Use oracles from an on-chain program to access real-world data"
+                ]
             },
             {
                 "title": "Verifiable randomness functions",
                 "slug": "vrf",
                 "number": 3,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Explain the limitations of generating random numbers on-chain",
+                    "Explain how Verifiable Randomness works",
+                    "Use Switchboard's VRF oracle queue to generate and consume randomness from an on-chain program"
+                ]
             },
             {
                 "title": "Compressed NFTs",
                 "slug": "compressed-nfts",
                 "number": 4,
-                "hidden": false
+                "hidden": false,
+                "objectives": [
+                    "Create a compressed NFT collection using Metaplex’s Bubblegum program",
+                    "Mint compressed NFTs using the Bubblegum TS SDK",
+                    "Transfer compressed NFTs using the Bubblegum TS SDK",
+                    "Read compressed NFT data using the Read API"
+                ]
             }
         ]
     }

--- a/course-structure.json
+++ b/course-structure.json
@@ -4,7 +4,7 @@
         "number": 0,
         "lessons": [
             {
-                "title": "Getting started",
+                "title": "Get started",
                 "slug": "getting-started",
                 "objectives": [
                     "understand what web3 is",
@@ -110,17 +110,17 @@
                 "number": 1
             },
             {
-                "title": "Create a Basic Program, Part 1 - Handle Instruction Data",
+                "title": "Handle Instruction Data",
                 "slug": "deserialize-instruction-data",
                 "number": 2
             },
             {
-                "title": "Create a Basic Program, Part 2 - State Management",
+                "title": "State Management",
                 "slug": "program-state-management",
                 "number": 3
             },
             {
-                "title": "Create a Basic Program, Part 3 - Basic Security and Validation",
+                "title": "Basic Security and Validation",
                 "slug": "program-security",
                 "number": 4
             }

--- a/course-structure.json
+++ b/course-structure.json
@@ -405,6 +405,7 @@
                 ],
                 "translations": {
                     "es": {
+                        "title": "Objetivos de desarrollo del programa local",
                         "objectives": [
                             "Crear un entorno local para el desarrollo del programa Solana",
                             "Usar comandos CLI básicos de Solana",
@@ -853,6 +854,7 @@
                 ],
                 "translations": {
                     "es": {
+                        "title": "Bump Seed Canonicalization objetivos",
                         "objectives": [
                             "Explicar las vulnerabilidades asociadas con el uso de PDA derivados sin el bache canónico",
                             "Inicializar un PDA usando Anchor 's `seeds` y `bump` restricciones para usar automáticamente el bache canónico",
@@ -919,7 +921,8 @@
                     "Make better PDA design decisions",
                     "Future-proof your programs",
                     "Deal with concurrency issues"
-                ]
+                ],
+                "translations": {}
             },
             {
                 "title": "Oracles and oracle networks",
@@ -932,7 +935,8 @@
                     "Explain how incentivized oracle networks make data more trustworthy",
                     "Effectively weigh the tradeoffs between using various types of oracles",
                     "Use oracles from an on-chain program to access real-world data"
-                ]
+                ],
+                "translations": {}
             },
             {
                 "title": "Verifiable randomness functions",
@@ -943,7 +947,8 @@
                     "Explain the limitations of generating random numbers on-chain",
                     "Explain how Verifiable Randomness works",
                     "Use Switchboard's VRF oracle queue to generate and consume randomness from an on-chain program"
-                ]
+                ],
+                "translations": {}
             },
             {
                 "title": "Compressed NFTs",
@@ -955,7 +960,8 @@
                     "Mint compressed NFTs using the Bubblegum TS SDK",
                     "Transfer compressed NFTs using the Bubblegum TS SDK",
                     "Read compressed NFT data using the Read API"
-                ]
+                ],
+                "translations": {}
             }
         ]
     }

--- a/course-structure.json
+++ b/course-structure.json
@@ -12,7 +12,8 @@
                     "learn how this course is structured",
                     "know how to get the most from this course"
                 ],
-                "number": 1
+                "number": 1,
+                "hidden": false
             }
         ]
     },
@@ -29,7 +30,8 @@
                     "Use `@solana/web3.js` to generate a new keypair",
                     "Use `@solana-developers/node-helpers` to load a keypair from an env file"
                 ],
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Read data from the network",
@@ -43,7 +45,8 @@
                     "Use web3.js to create a connection to a Solana node",
                     "Use web3.js to read data from the blockchain (balance, account info, etc.)"
                 ],
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Write data to the network",
@@ -55,27 +58,32 @@
                     "Use `@solana/web3.js` to sign transactions",
                     "Use Solana explorer to view transactions"
                 ],
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Interact with wallets",
                 "slug": "interact-with-wallets",
-                "number": 4
+                "number": 4,
+                "hidden": false
             },
             {
                 "title": "Serialize program data",
                 "slug": "serialize-instruction-data",
-                "number": 5
+                "number": 5,
+                "hidden": false
             },
             {
                 "title": "Deserialize program data",
                 "slug": "deserialize-custom-data",
-                "number": 6
+                "number": 6,
+                "hidden": false
             },
             {
                 "title": "Page, Order, and Filter program data",
                 "slug": "paging-ordering-filtering-data",
-                "number": 7
+                "number": 7,
+                "hidden": false
             }
         ]
     },
@@ -86,17 +94,20 @@
             {
                 "title": "Create tokens with the Token Program",
                 "slug": "token-program",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Swap tokens with the Token Swap Program",
                 "slug": "token-swap",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Create Solana NFTs With Metaplex",
                 "slug": "nfts-with-metaplex",
-                "number": 3
+                "number": 3,
+                "hidden": false
             }
         ]
     },
@@ -107,22 +118,26 @@
             {
                 "title": "Hello World",
                 "slug": "hello-world-program",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Handle Instruction Data",
                 "slug": "deserialize-instruction-data",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "State Management",
                 "slug": "program-state-management",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Basic Security and Validation",
                 "slug": "program-security",
-                "number": 4
+                "number": 4,
+                "hidden": false
             }
         ]
     },
@@ -133,17 +148,20 @@
             {
                 "title": "Local Program Development",
                 "slug": "local-setup",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Program Derived Addresses",
                 "slug": "pda",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Cross Program Invocations",
                 "slug": "cpi",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Program Testing - COMING SOON",
@@ -160,22 +178,26 @@
             {
                 "title": "Intro to Anchor development",
                 "slug": "intro-to-anchor",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Intro to client-side Anchor development",
                 "slug": "intro-to-anchor-frontend",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Anchor PDAs and accounts",
                 "slug": "anchor-pdas",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Anchor CPIs and errors",
                 "slug": "anchor-cpi",
-                "number": 4
+                "number": 4,
+                "hidden": false
             }
         ]
     },
@@ -186,22 +208,26 @@
             {
                 "title": "Environment variables in Solana programs",
                 "slug": "env-variables",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Solana Pay",
                 "slug": "solana-pay",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Versioned transactions and lookup tables",
                 "slug": "versioned-transaction",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Rust procedural macros",
                 "slug": "rust-macros",
-                "number": 4
+                "number": 4,
+                "hidden": false
             }
         ]
     },
@@ -212,57 +238,68 @@
             {
                 "title": "How to approach the Program Security module",
                 "slug": "security-intro",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Signer authorization",
                 "slug": "signer-auth",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Owner checks",
                 "slug": "owner-checks",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Account data matching",
                 "slug": "account-data-matching",
-                "number": 4
+                "number": 4,
+                "hidden": false
             },
             {
                 "title": "Reinitialization attacks",
                 "slug": "reinitialization-attacks",
-                "number": 5
+                "number": 5,
+                "hidden": false
             },
             {
                 "title": "Duplicate mutable accounts",
                 "slug": "duplicate-mutable-accounts",
-                "number": 6
+                "number": 6,
+                "hidden": false
             },
             {
                 "title": "Type cosplay",
                 "slug": "type-cosplay",
-                "number": 7
+                "number": 7,
+                "hidden": false
             },
             {
                 "title": "Arbitrary CPIs",
                 "slug": "arbitrary-cpi",
-                "number": 8
+                "number": 8,
+                "hidden": false
             },
             {
                 "title": "Bump seed canonicalization",
                 "slug": "bump-seed-canonicalization",
-                "number": 9
+                "number": 9,
+                "hidden": false
             },
             {
                 "title": "Closing accounts and revival attacks",
                 "slug": "closing-accounts",
-                "number": 10
+                "number": 10,
+                "hidden": false
             },
             {
                 "title": "PDA sharing",
                 "slug": "pda-sharing",
-                "number": 11
+                "number": 11,
+                "hidden": false
             }
         ]
     },
@@ -273,22 +310,26 @@
             {
                 "title": "Program architecture",
                 "slug": "program-architecture",
-                "number": 1
+                "number": 1,
+                "hidden": false
             },
             {
                 "title": "Oracles and oracle networks",
                 "slug": "oracles",
-                "number": 2
+                "number": 2,
+                "hidden": false
             },
             {
                 "title": "Verifiable randomness functions",
                 "slug": "vrf",
-                "number": 3
+                "number": 3,
+                "hidden": false
             },
             {
                 "title": "Compressed NFTs",
                 "slug": "compressed-nfts",
-                "number": 4
+                "number": 4,
+                "hidden": false
             }
         ]
     }

--- a/src/lib/components/navigation.svelte
+++ b/src/lib/components/navigation.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import type { Lesson } from "$lib/types";
+  import type { PageData } from "$lib/types";
   import leftImage from "$lib/assets/left.svg";
   import rightImage from "$lib/assets/right.svg";
 
-  export let data: Lesson;
+  // 'data' is a bad variable name, but it's what SvelteKit uses
+  export let data: PageData;
 
   const UP = "../";
 </script>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ export type Module = {
   lessons: Array<{
     title: string;
     slug: string;
-    hidden?: boolean;
+    hidden: boolean;
   }>;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-type Translation = Record<
+type TranslationsByLanguage = Record<
   string,
   {
     title: string;
@@ -12,13 +12,14 @@ export type Lesson = {
   objectives: Array<string>;
   number: number;
   hidden: boolean;
-  translations: Array<Translation>;
+  translations: TranslationsByLanguage | {};
 };
 
 // TODO: we can remove the 'number' key from course-structure.json
 // as it duplicates the index, once we move the site to solana.com
 export type Module = {
   title: string;
+  number: number;
   lessons: Array<Lesson>;
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,12 +1,25 @@
+type Translation = Record<
+  string,
+  {
+    title: string;
+    objectives: Array<string>;
+  }
+>;
+
+export type Lesson = {
+  title: string;
+  slug: string;
+  objectives: Array<string>;
+  number: number;
+  hidden: boolean;
+  translations: Array<Translation>;
+};
+
 // TODO: we can remove the 'number' key from course-structure.json
 // as it duplicates the index, once we move the site to solana.com
 export type Module = {
   title: string;
-  lessons: Array<{
-    title: string;
-    slug: string;
-    hidden: boolean;
-  }>;
+  lessons: Array<Lesson>;
 };
 
 // See https://stackoverflow.com/questions/40141005/property-code-does-not-exist-on-type-error?noredirect=1
@@ -17,7 +30,7 @@ export type NodeError = {
   code?: number | string;
 };
 
-export type Lesson = {
+export type PageData = {
   title: string;
   content: string;
   nextSlug: string | null;

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,6 +1,7 @@
 import modules from "../../../course-structure.json";
-import type { NodeError } from "$lib/types";
+import type { Lesson, NodeError } from "$lib/types";
 import { error as makeSvelteError } from "@sveltejs/kit";
+import type { PageData } from "$lib/types";
 // I assure you, node still has an fs module.
 // @ts-ignore
 import { readFile } from "node:fs/promises";
@@ -15,14 +16,9 @@ const cleanContent = (content: string) => {
   return content.replaceAll("../assets", "");
 };
 
-// Ignore 'hidden' for now.
-interface Lesson {
-  title: string;
-  slug: string;
-}
-
-export async function load({ params }) {
-  const lessons = modules.flatMap((module) => module.lessons);
+// See https://kit.svelte.dev/docs/load
+export async function load({ params }): Promise<PageData> {
+  const lessons = modules.flatMap((module) => module.lessons) as Array<Lesson>;
 
   const hasThisSlug = (lesson: Lesson) => lesson.slug === params.slug;
 

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -18,7 +18,9 @@ const cleanContent = (content: string) => {
 
 // See https://kit.svelte.dev/docs/load
 export async function load({ params }): Promise<PageData> {
-  const lessons = modules.flatMap((module) => module.lessons) as Array<Lesson>;
+  const allLessons = modules.flatMap((module) => module.lessons);
+
+  const lessons = allLessons.filter((lesson) => !lesson.hidden);
 
   const hasThisSlug = (lesson: Lesson) => lesson.slug === params.slug;
 

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -8,18 +8,11 @@ import { readFile } from "node:fs/promises";
 import { marked } from "marked";
 
 const cleanContent = (content: string) => {
-  // There's a bunch of metadata in the content that should really be in the course structure.
-  // let's strip that out.
-  // TODO: remove this content permanently after we retire Soldev
-  let cleanContent = content.split("---").reverse()[0];
-
   // Paths in the content need adjusting from the old soldev-ui location
   // TODO: fix this in the actual content.
   // TODO: we may also wish to move the content to the lib/assets directory
   // at the same time.
-  cleanContent = cleanContent.replaceAll("../assets", "");
-
-  return cleanContent;
+  return content.replaceAll("../assets", "");
 };
 
 // Ignore 'hidden' for now.

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Header from "$lib/components/header.svelte";
   import Navigation from "$lib/components/navigation.svelte";
-  import type { Lesson } from "$lib/types";
+  import type { PageData } from "$lib/types";
   import { onMount, tick } from "svelte";
   import hljs from "highlight.js";
   // Highlight JS theme
@@ -9,7 +9,8 @@
   import "highlight.js/styles/stackoverflow-light.css";
   import { log, sleep } from "$lib/functions";
 
-  export let data: Lesson;
+  // 'data' is a bad variable name, but it's what SvelteKit uses
+  export let data: PageData;
 
   const highlight = async () => {
     if (!globalThis.document) {


### PR DESCRIPTION
Move translations into the actual course-structure. This will:

 - make it easier in future as there's a single place to look up every aspect of a lesson (because everything that's not content is in course structure)
 - Allow us to do translations easier (because everything that's not content is in course structure)
 - Avoid workarounds for markdown parsers not expecting YAML inside markdown files

This course also contains some minor fixes to course-structure, adding the 'hidden' key (set to false) for modules where it's missing. and making the tone more consistent between titles ('Get' rather than 'Getting' etc), and simplifies the TS types.