### PR TITLE
feat: update first unit for more deliberate learning 

### DIFF
--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -1,0 +1,265 @@
+---
+title: Using custom on-chain programs
+objectives:
+- Create transactions for custom on-chain programs
+---
+
+# TL;DR
+
+Solana has multiple on-chain programs you can use. Instructions that use these programs need to have data in a custom format determined by the program.
+
+# Overview
+### Instructions
+
+In previous chapters, we used `SystemProgram.transfer()` function to create and instruction to send Solana. 
+
+When working with non-native programs, however, you’ll need to be more specific about creating instructions that are structured to match the corresponding program.
+
+With `@solana/web3.js`, you can create non-native instructions with the `TransactionInstruction` constructor. This constructor takes a single argument of the data type `TransactionInstructionCtorFields`.
+
+```typescript
+export type TransactionInstructionCtorFields = {
+  keys: Array<AccountMeta>;
+  programId: PublicKey;
+  data?: Buffer;
+};
+```
+
+Per the definition above, the object passed to the `TransactionInstruction` constructor requires:
+
+- an array of keys of type `AccountMeta`
+- the public key for the program being called
+- an optional `Buffer` containing data to pass to the program.
+
+We’ll be ignoring the `data` field for now and will revisit it in a future lesson.
+
+The `programId` field is fairly self explanatory: it’s the public key associated with the program. You’ll need to know this in advance of calling the program in the same way that you’d need to know the public key of someone to whom you want to send SOL.
+
+The `keys` array requires a bit more explanation. Each object in this array represents an account that will be read from or written to during a transaction's execution. This means you need to know the behavior of the program you are calling and ensure that you provide all of the necessary accounts in the array.
+
+Each object in the `keys` array must include the following:
+- `pubkey` - the public key of the account
+- `isSigner` - a boolean representing whether or not the account is a signer on the transaction
+- `isWritable` - a boolean representing whether or not the account is written to during the transaction's execution
+
+Putting this all together, we might end up with something like the following:
+
+```typescript
+async function callProgram(
+  connection: web3.Connection,
+  payer: web3.Keypair,
+  programId: web3.PublicKey,
+  programDataAccount: web3.PublicKey,
+) {
+  const instruction = new web3.TransactionInstruction({
+    keys: [
+      {
+        pubkey: programDataAccount,
+        isSigner: false,
+        isWritable: true,
+      },
+    ],
+    programId,
+  });
+
+  const transaction = new web3.Transaction().add(instruction)
+
+  const signature = await web3.sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [payer],
+  );
+
+  console.log(`✅ Success! Transaction signature is: ${signature}`);
+}
+```
+
+### Transaction Fees
+
+Transaction fees are built into the Solana economy as compensation to the validator network for the CPU and GPU resources required in processing transactions. Solana transaction fees are deterministic.
+
+The first signer included in the array of signers on a transaction is responsible for paying the transaction fee. If this signer does not have enough SOL in their account to cover the transaction fee, the transaction will be dropped.
+
+When testing, whether locally or on devnet, you can use the Solana CLI command `solana airdrop 1` to get free test SOL in your account for paying transaction fees.
+
+### Solana Explorer
+
+![Screenshot of Solana Explorer set to Devnet](../assets/solana-explorer-devnet.png)
+
+All transactions on the blockchain are publicly viewable on the [Solana Explorer](http://explorer.solana.com). For example, you could take the signature returned by `sendAndConfirmTransaction()` in the example above, search for that signature in the Solana Explorer, then see:
+
+- when it occurred
+- which block it was included in
+- the transaction fee
+- and more!
+
+![Screenshot of Solana Explorer with details about a transaction](../assets/solana-explorer-transaction-overview.png)
+
+# Lab - wriuting transaction for the ping counter program 
+
+We’re going to create a script to ping an on-chain program that increments a counter each time it has been pinged. This program exists on the Solana Devnet at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores it's data in a specific account at the address `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
+
+![Solana stores programs and data in seperate accounts](../assets/pdas-note-taking-program.svg)
+
+### 1. Basic scaffolding
+
+We'll start by using the same packages and `.env` file we made earlier in [intro to cryptography](./intro-to-cryptography.md):
+
+```typescript
+import { Keypair } from "@solana/web3.js";
+import * as dotenv from "dotenv";
+import base58 from "bs58";
+import { getKeypairFromEnvironment } from "@solana-developers/node-helpers"
+
+dotenv.config();
+
+const payer = getKeypairFromEnvironment('SECRET_KEY')
+const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
+
+```
+
+### 4. Ping program
+
+Now that we've loaded our keypair, we need to connect to Solana’s Devnet. Let's create a connection:
+
+```typescript
+const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
+```
+
+Now create an async function called `sendPingTransaction()` with two parameters requiring a connection and payer’s keypair as arguments:
+
+```typescript
+async function sendPingTransaction(connection: web3.Connection, payer: web3.Keypair) { }
+```
+
+Inside this function, we need to:
+
+1. create a transaction
+2. create an instruction
+3. add the instruction to the transaction
+4. send the transaction.
+
+Remember, the most challenging piece here is including the right information in the instruction. We know the address of the program that we are calling. We also know that the program writes data to a separate account whose address we also have. Let’s add the string versions of both of those as constants at the top of the `index.ts` file:
+
+```typescript
+const PING_PROGRAM_ADDRESS = new web3.PublicKey('ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa')
+const PING_PROGRAM_DATA_ADDRESS =  new web3.PublicKey('Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod')
+```
+
+Now, in the `sendPingTransaction()` function, let’s create a new transaction, then initialize a `PublicKey` for the program account, and another for the data account.
+
+```typescript
+const transaction = new web3.Transaction()
+const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
+const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
+```
+
+Next, let’s create the instruction. Remember, the instruction needs to include the public key for the Ping program and it also needs to include an array with all the accounts that will be read from or written to. In this example program, only the data account referenced above is needed.
+
+```typescript
+const transaction = new web3.Transaction()
+
+const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
+const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
+
+const instruction = new web3.TransactionInstruction({
+  keys: [
+    {
+      pubkey: pingProgramDataId,
+      isSigner: false,
+      isWritable: true
+    },
+  ],
+  programId
+})
+```
+
+Next, let’s add the instruction to the transaction we created. Then, call `sendAndConfirmTransaction()` by passing in the connection, transaction, and payer. Finally, let’s log the result of that function call so we can look it up on the Solana Explorer.
+
+```typescript
+const transaction = new web3.Transaction()
+
+const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
+const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
+
+const instruction = new web3.TransactionInstruction({
+  keys: [
+    {
+      pubkey: pingProgramDataId,
+      isSigner: false,
+      isWritable: true
+    },
+  ],
+  programId
+})
+
+transaction.add(instruction)
+
+const signature = await web3.sendAndConfirmTransaction(
+  connection,
+  transaction,
+  [payer]
+)
+
+console.log(`✅ Transaction completed! Signature is ${signature}`)
+```
+
+### 5. Airdrop
+
+Now run the code with `npx esrun send-ping-instruction.ts` and see if it works. You may end up with the following error in the console:
+
+```
+> Transaction simulation failed: Attempt to debit an account but found no record of a prior credit.
+```
+
+If you get this error, it’s because your keypair is brand new and doesn’t have any SOL to cover the transaction fees. Let’s fix this by adding the following line before the call to `sendPingTransaction()`:
+
+```typescript
+await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL*1)
+```
+
+This will deposit 1 SOL into your account which you can use for testing. This won’t work on Mainnet where it would actually have value. But it's incredibly convenient for testing locally and on Devnet.
+
+### 6. Check the Solana explorer
+
+Now run the code again. It may take a moment or two, but now the code should work and you should see a long string printed to the console, like the following:
+
+```
+✅ Transaction completed! Signature is 55S47uwMJprFMLhRSewkoUuzUs5V6BpNfRx21MpngRUQG3AswCzCSxvQmS3WEPWDJM7bhHm3bYBrqRshj672cUSG
+```
+
+Copy the transaction signature. Open a browser and go to [https://explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet) (the query parameter at the end of the URL will ensure that you’ll explore transactions on Devnet instead of Mainnet). Paste the signature into the search bar at the top of Solana’s Devnet explorer and hit enter. You should see all the details about the transaction. If you scroll all the way to the bottom, then you will see `Program Logs`, which show how many times the program has been pinged including your ping.
+
+![Screenshot of Solana Explorer with logs from calling the Ping program](../assets/solana-explorer-ping-result.png)
+
+Scroll around the Explorer and look at what you're seeing:
+ - The **Account Input(s)** will include: 
+  - The address of your payer - being debited 5000 lamports for the transaction
+  - The program address for the ping program
+  - The data address for the ping program
+ - The **Instruction** section will contain a single instructionm, with no data - the ping program is a pretty simple program, so it doesn't need any data.
+ - The **Program Instruction Logs** shows the logs from the ping program.  
+
+[//]: # "TODO: these would make a good question-and-answer interactive once we have this content hosted on solana.com, and can support adding more interactive content easily."
+
+If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` in `sendPingTransaction()` to the following:
+
+```typescript
+console.log(`You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${signature}?cluster=devnet`)
+```
+
+And just like that you’re calling programs on the Solana network and writing data to chain!
+
+### Next steps
+
+In the next few lessons you’ll learn how to
+
+1. Send transactions safely from the browser instead of from running a script
+2. Add custom data to your instructions
+3. Deserialize data from the chain
+
+# Challenge
+
+Go ahead and create a script from scratch that will allow you to transfer SOL from one account to another on Devnet. Be sure to print out the transaction signature so you can look at it on the Solana Explorer.
+
+If you get stuck feel free to glance at the [solution code](https://github.com/Unboxed-Software/solana-ping-client).

--- a/content/intro-to-reading-data.md
+++ b/content/intro-to-reading-data.md
@@ -10,11 +10,11 @@ objectives:
 
 - **SOL** is the name of Solana’s native token. Each SOL is made from 1 billion **Lamports**. 
 - **Accounts** store tokens, NFTs, programs, and data. For now we’ll focus on accounts that store SOL. 
-- **Addresses** point to accounts on the Solana network. Anyone can read the data in a given address. Most addresses are also **public keys**
+- **Addresses** point to accounts on the Solana network. Anyone can read the data in a given address. Most addresses are also **public keys**.
 
 # Overview
 
-## Accounts
+### Accounts
 
 All data stored on Solana is stored in accounts. Accounts can store: 
 
@@ -22,21 +22,23 @@ All data stored on Solana is stored in accounts. Accounts can store:
 - Other tokens, like USDC
 - NFTs
 - Programs, like the film review program we make in this course!
-- Program data, like a review for a particular film for the program above!
+- Program data, like a film review for the program above!
 
 ### SOL
 
-SOL is Solana's native token - SOL is used to pay transaction fees, pay rent for accounts, and more. SOL is sometimes shown with the `◎` symbol. Each SOL is made from 1 billion **Lamports**. In the same way that finance apps typically do math in cents (for USD), pence (for GBP), Solana apps typically use do math using Lamports and only convert to SOL to display data.  
+SOL is Solana's native token - SOL is used to pay transaction fees, pay rent for accounts, and more. SOL is sometimes shown with the `◎` symbol. Each SOL is made from 1 billion **Lamports**. 
+
+In the same way that finance apps typically do math in cents (for USD), pence (for GBP), Solana apps typically transfer, spend, store and handle SOL as Lamports, only converting to full SOL to display to users. 
 
 ### Addresses
 
-Addresses uniquely identify accounts. Addresses are often shown as base-58 encoded strings like `dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8`. Most addresses on Solana are also **public keys**. As mentioned in the previous chapter, whoever controls the matching secret key controls the account - for example, the person with the secret key can send tokens from the account.
+Addresses uniquely identify accounts. Addresses are often shown as base-58 encoded strings like `dDCQNnDmNbFVi8cQhKAgXhyhXeJ625tvwsunRyRc7c8`. Most addresses on Solana are also **public keys**. As mentioned in the previous chapter, whoever controls the matching secret key for an address controls the account - for example, the person with the secret key can send tokens from the account.
 
 ## Reading from the Solana Blockchain
 
 ### Installation
 
-We use an npm package called `@solana/web3.js` to do most of the work with Solana. We'll also install TypeScript and esrun, so we can run command line:
+We use an npm package called `@solana/web3.js` to do most of the work with Solana. We'll also install TypeScript and `esrun`, so we can run `.ts` files on the command line:
 
 ```bash
 npm install typescript @solana/web3.js @digitak/esrun 
@@ -46,7 +48,7 @@ npm install typescript @solana/web3.js @digitak/esrun
 
 Every interaction with the Solana network using `@solana/web3.js` is going to happen through a `Connection` object. The `Connection` object establishes a connection with a specific Solana network, called a 'cluster'. 
 
-For now we'll use the `Devnet` cluster rather than `Mainnet`. As the name suggests, the `Devnet` cluster is designed for developer use and testing.
+For now we'll use the `Devnet` cluster rather than `Mainnet`. `Devnet` is designed for developer use and testing, and `DevNet` tokens don't have real value.
 
 ```typescript
 import { Connection, clusterApiUrl } from "@solana/web3.js";
@@ -76,7 +78,7 @@ console.log(`The balance of the account at ${address} is ${balance} lamports`);
 console.log(`✅ Finished!`)
 ```
 
-The balance returned is in *lamports*. A lamport is the minor unit for SOL, like cents is to US Dollars, or pence is to British pounds. A single lamport represents 0.000000001 SOL. Most of the time we'll transfer, spend, store and handle SOL as Lamports, only converting to full SOL to display to users. Web3.js provides the constant `LAMPORTS_PER_SOL` for making quick conversions.
+The balance returned is in *lamports*, as discusssed earlier. Web3.js provides the constant `LAMPORTS_PER_SOL` for showing Lamports as SOL:
 
 ```typescript
 import { Connection, PublicKey, clusterApiUrl, LAMPORTS_PER_SOL } from "@solana/web3.js";
@@ -101,90 +103,95 @@ The balance of the account at CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN is 0.
 
 # Lab
 
-Let’s practice what we’ve learned, and create a simple website that lets users check the balance at a particular address.
+Let’s practice what we’ve learned, and check the balance at a particular address. 
 
-It’ll look something like this:
+## Load a keypair 
 
-![Screenshot of demo solution](../assets/intro-frontend-demo.png)
+Remember the public key from the previous chapter. 
 
-In the interest of staying on topic, we won’t be working entirely from scratch, so [download the starter code](https://github.com/Unboxed-Software/solana-intro-frontend/tree/starter). The starter project uses Next.js and Typescript. If you’re used to a different stack, don’t worry! The web3 and Solana principles you’ll learn throughout these lessons are applicable to whichever frontend stack you’re most comfortable with.
+Make a new file called `check-balance.ts`, substituting your public key in for `<your public key>`.
 
-### 1. Get oriented
+The script loads the public key, connects to DevNet, and checks the balance:
 
-Once you’ve got the starter code, take a look around. Install the dependencies with `npm install` and then run the app with `npm run dev`. Notice that no matter what you put into the address field, when you click “Check SOL Balance” the balance will be a placeholder value of 1000.
+```
+import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 
-Structurally, the app is composed of `index.tsx` and `AddressForm.tsx`. When a user submits the form, the `addressSubmittedHandler` in `index.tsx` gets called. That’s where we’ll be adding the logic to update the rest of the UI.
+const publicKey = new PublicKey("<your public key>");
 
-### 2. Install dependencies
+const connection = new Connection("https://api.devnet.solana.com", "confirmed");
 
-Use `npm install @solana/web3.js` to install our dependency on Solana’s web3 library.
+const balanceInLamports = await connection.getBalance(publicKey);
 
-### 3. Set the address balance
+const balanceInSOL = balanceInLamports / LAMPORTS_PER_SOL;
 
-First, import `@solana/web3.js` at the top of `index.tsx`.
+console.log(
+  `💰 Finished! The balance for the wallet at address ${publicKey} is ${balanceInSOL}!`
+);
 
-Now that the library is available, let’s go into the `addressSubmittedHandler()` and create an instance of `PublicKey` using the address value from the form input. Next, create an instance of `Connection` and use it to call `getBalance()`. Pass in the value of the public key you just created. Finally, call `setBalance()`, passing in the result from `getBalance`. If you’re up to it, try this independently instead of copying from the code snippet below.
+```
 
-```typescript
-import type { NextPage } from 'next'
-import { useState } from 'react'
-import styles from '../styles/Home.module.css'
-import AddressForm from '../components/AddressForm'
-import * as web3 from '@solana/web3.js'
+Save this to a file, and `npx esrun check-balance.ts`. You should something like:
 
-const Home: NextPage = () => {
-  const [balance, setBalance] = useState(0)
-  const [address, setAddress] = useState('')
+```
+💰 Finished! The balance for the wallet at address 31ZdXAvhRQyzLC2L97PC6Lnf2yWgHhQUKKYoUo9MLQF5 is 0!
+```
 
-  const addressSubmittedHandler = async (address: string) => {
-    setAddress(address)
-    const key = new web3.PublicKey(address)
-    const connection = new web3.Connection(web3.clusterApiUrl('devnet'));
-    const balance = await connection.getBalance(key);
-    setBalance(balance / web3.LAMPORTS_PER_SOL);
-  }
-  ...
+## Get Devnet Sol
+
+In Devnet you can get free SOL to develop with. Think of Devnet SOL like board game money - it looks like it has value, but it doesn't have value. 
+
+[Get some Devnet SOL](https://faucet.solana.com/) and use the public key of your keypair as the address. 
+
+Pick any amount of SOL you like.
+
+## Check your balance
+
+Re-run the script. You should see your balance updated:
+
+```
+💰 Finished! The balance for the wallet at address 31ZdXAvhRQyzLC2L97PC6Lnf2yWgHhQUKKYoUo9MLQF5 is 0.5!
+```
+
+## Check other student's balances
+
+You can modify the script to check balances on any wallet.
+
+```
+import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+
+const suppliedPublicKey = process.argv[2];
+if (!suppliedPublicKey) {
+  throw new Error("Provide a public key to check the balance of!");
 }
+
+const connection = new Connection("https://api.devnet.solana.com", "confirmed");
+
+const publicKey = new PublicKey(suppliedPublicKey);
+
+const balanceInLamports = await connection.getBalance(publicKey);
+
+const balanceInSOL = balanceInLamports / LAMPORTS_PER_SOL;
+
+console.log(
+  `✅ Finished! The balance for the wallet at address ${publicKey} is ${balanceInSOL}!`
+);
+
 ```
 
-Most of the time when dealing with SOL, the system will use lamports instead of SOL. Since computers are better at handing whole numbers than fractions, we generally do most of our transactions in whole lamports, only converting back to SOL to display the value to users. This is why we take the balance returned by Solana and divide it by `LAMPORTS_PER_SOL`. 
+Swap wallet addresses with your classmates in the chat and check their balances.
 
-Before setting it to our state, we also convert it to SOL using the `LAMPORTS_PER_SOL` constant.
-
-At this point you should be able to put a valid address into the form field and click “Check SOL Balance” to see both the Address and Balance populate below.
-
-### 4. Handle invalid addresses
-
-We’re just about done. The only remaining issue is that using an invalid address doesn’t show any error message or change the balance shown. If you open the developer console, you’ll see `Error: Invalid public key input`. When using the `PublicKey` constructor, you need to pass in a valid address or you’ll get this error.
-
-To fix this, let’s wrap everything in a `try-catch` block and alert the user if their input is invalid.
-
-```typescript
-const addressSubmittedHandler = async (address: string) => {
-  try {
-    setAddress(address);
-    const key = new web3.PublicKey(address);
-    const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
-    const balance = await connection.getBalance(key)
-    setBalance(balance / web3.LAMPORTS_PER_SOL);
-  } catch (error) {
-    setAddress("");
-    setBalance(0);
-    alert(error);
-  }
-};
+```
+% npx esrun check-balance.ts (some wallet address)
+✅ Finished! The balance for the wallet at address 31ZdXAvhRQyzLC2L97PC6Lnf2yWgHhQUKKYoUo9MLQF5 is 3!
 ```
 
-Notice that in the catch block we also cleared out the address and balance to avoid confusion.
-
-We did it! We have a functioning site that reads SOL balances from the Solana network. You’re well on your way to achieving your grand ambitions on Solana. If you need to spend some more time looking at this code to better understand it, have a look at the complete [solution code](https://github.com/Unboxed-Software/solana-intro-frontend). Hang on tight, these lessons will ramp up quickly.
+And check a few of your classmate's balances.
 
 # Challenge
 
-Since this is the first challenge, we’ll keep it simple. Go ahead and add on to the frontend we’ve already created by including a line item after “Balance”. Have the line item display whether or not the account is an executable account or not. Hint: there’s a `getAccountInfo()` method.
+Modify the script as follows:
 
-Since this is DevNet, your regular mainnet wallet address will _not_ be executable, so if you want an address that _will_ be executable for testing, use `CenYq6bDRB7p73EjsPEpiYN7uveyPUTdXkDkgUduboaN`.
+ - Add instructions to handle invalid wallet addresses.
+ - Modify the script to connect to `mainNet` and look up some famous Solana wallets. Try `toly.sol`, `shaq.sol` or `mccann.sol`.
 
-![Screenshot of final challenge solution](../assets/intro-frontend-challenge.png)
-
-If you get stuck feel free to take a look at the [solution code](https://github.com/Unboxed-Software/solana-intro-frontend/tree/challenge-solution).
+We'll transfer SOL in the next lesson!

--- a/content/intro-to-writing-data.md
+++ b/content/intro-to-writing-data.md
@@ -1,5 +1,5 @@
 ---
-title: Write Data To The Solana Network
+title: Create Transactions on the Solana Network
 objectives:
 - Explain transactions
 - Explain transaction fees
@@ -14,21 +14,36 @@ All modifications to on-chain data happen through **transactions**. Transactions
 
 # Overview
 
-## Transactions
+## Transactions are atomic
 
 Any modification to on-chain data happens through transactions sent to programs.
 
-Transaction instructions contain:
+A transaction on Solana is similar to a transaction elsewhere: it is atomic. **Atomic means the entire transaction runs or fails**. 
 
-- an identifier of the program you intend to invoke
-- an array of accounts that will be read from and/or written to
-- data structured as a byte array that is specified to the program being invoked
+Think of paying for something online: 
 
-When you send a transaction to a Solana cluster, a Solana program is invoked with the instructions included in the transaction.
+ - The balance of your account is debited
+ - The bank transfers the funds to the merchant
+
+Both of these things need to happen for the transaction to be successful. If either of them fail, it is better that none of these things happen, rather than pay the merchant and not debit your account, or debit the account but not pay the merchant. 
+
+Atomic means either the transaction happens - meaning all the individual steps succeed - or the entire transaction fails.
+
+## Transactions contain instructions
+
+The steps within transaction on Solana are called **instructions**. 
+
+Each instruction contains:
+
+- an array of accounts that will be read from and/or written to. This is what makes Solana fast - transactions that affect different accounts are processed simultaneously
+- the public key of the program to invoke
+- data passed to the program being invoked, structured as a byte array
+
+When a transaction is run, one or more Solana programs are invoked with the instructions included in the transaction.
 
 As you might expect, `@solana/web3.js` provides helper functions for creating transactions and instructions. You can create a new transaction with the constructor, `new Transaction()`. Once created, then you can add instructions to the transaction with the `add()` method.
 
-One of those helper function is `SystemProgram.transfer()`, which makes an instruction for transferring SOL:
+One of those helper functions is `SystemProgram.transfer()`, which makes an instruction for transferring SOL:
 
 ```typescript
 const transaction = new Transaction()
@@ -48,7 +63,11 @@ The `SystemProgram.transfer()` function requires:
 - a public key corresponding to the recipient account
 - the amount of SOL to send in lamports.
 
-`SystemProgram.transfer()` returns the instruction for sending SOL from the sender to the recipient. The instruction can then be added to the transaction.
+`SystemProgram.transfer()` returns the instruction for sending SOL from the sender to the recipient. 
+
+The program used in this instruction will be the `system` program (at address `11111111111111111111111111111111`), the data will be the amount of SOL to transfer (in Lamports) and the accounts will be based on the sender and recipient. 
+
+The instruction can then be added to the transaction.
 
 Once all the instructions have been added, a transaction needs to be sent to the cluster and confirmed:
 
@@ -66,70 +85,7 @@ The `sendAndConfirmTransaction()` functions takes as parameters
 - a transaction
 - an array of keypairs that will act as signers on the transaction - in this example, we only have the one signer: the sender.
 
-### Instructions
-
-The example of sending SOL is great for introducing you to sending transactions, but a lot of web3 development will involve calling non-native programs. In the example above, the `SystemProgram.transfer()` function ensures that you pass all the necessary data required to create the instruction, then it creates the instruction for you. When working with non-native programs, however, you’ll need to be very specific about creating instructions that are structured to match the corresponding program.
-
-With `@solana/web3.js`, you can create non-native instructions with the `TransactionInstruction` constructor. This constructor takes a single argument of the data type `TransactionInstructionCtorFields`.
-
-```tsx
-export type TransactionInstructionCtorFields = {
-  keys: Array<AccountMeta>;
-  programId: PublicKey;
-  data?: Buffer;
-};
-```
-
-Per the definition above, the object passed to the `TransactionInstruction` constructor requires:
-
-- an array of keys of type `AccountMeta`
-- the public key for the program being called
-- an optional `Buffer` containing data to pass to the program.
-
-We’ll be ignoring the `data` field for now and will revisit it in a future lesson.
-
-The `programId` field is fairly self explanatory: it’s the public key associated with the program. You’ll need to know this in advance of calling the program in the same way that you’d need to know the public key of someone to whom you want to send SOL.
-
-The `keys` array requires a bit more explanation. Each object in this array represents an account that will be read from or written to during a transaction's execution. This means you need to know the behavior of the program you are calling and ensure that you provide all of the necessary accounts in the array.
-
-Each object in the `keys` array must include the following:
-- `pubkey` - the public key of the account
-- `isSigner` - a boolean representing whether or not the account is a signer on the transaction
-- `isWritable` - a boolean representing whether or not the account is written to during the transaction's execution
-
-Putting this all together, we might end up with something like the following:
-
-```tsx
-async function callProgram(
-  connection: web3.Connection,
-  payer: web3.Keypair,
-  programId: web3.PublicKey,
-  programDataAccount: web3.PublicKey,
-) {
-  const instruction = new web3.TransactionInstruction({
-    keys: [
-      {
-        pubkey: programDataAccount,
-        isSigner: false,
-        isWritable: true,
-      },
-    ],
-    programId,
-  });
-
-  const transaction = new web3.Transaction().add(instruction)
-
-  const signature = await web3.sendAndConfirmTransaction(
-    connection,
-    transaction,
-    [payer],
-  );
-
-  console.log(`✅ Success! Transaction signature is: ${signature}`);
-}
-```
-
-### Transaction Fees
+## Transactions have fees
 
 Transaction fees are built into the Solana economy as compensation to the validator network for the CPU and GPU resources required in processing transactions. Solana transaction fees are deterministic.
 
@@ -137,7 +93,7 @@ The first signer included in the array of signers on a transaction is responsibl
 
 When testing, whether locally or on devnet, you can use the Solana CLI command `solana airdrop 1` to get free test SOL in your account for paying transaction fees.
 
-### Solana Explorer
+## Solana Explorer
 
 ![Screenshot of Solana Explorer set to Devnet](../assets/solana-explorer-devnet.png)
 
@@ -152,9 +108,7 @@ All transactions on the blockchain are publicly viewable on the [Solana Explorer
 
 # Lab
 
-We’re going to create a script to ping an on-chain program that increments a counter each time it has been pinged. This program exists on the Solana Devnet at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores it's data in a specific account at the address `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
-
-![Solana stores programs and data in seperate accounts](../assets/pdas-note-taking-program.svg)
+We’re going to create a script to send SOL to other students.
 
 ### 1. Basic scaffolding
 
@@ -165,156 +119,63 @@ import { Keypair } from "@solana/web3.js";
 import * as dotenv from "dotenv";
 import base58 from "bs58";
 import { getKeypairFromEnvironment } from "@solana-developers/node-helpers"
+const toPubkey = new PublicKey(suppliedToPubkey);
 
 dotenv.config();
 
-const payer = getKeypairFromEnvironment('SECRET_KEY')
-const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
+const senderKeypair = getKeypairFromEnvironment("SECRET_KEY");
 
+const connection = new Connection("https://api.devnet.solana.com", "confirmed");
+
+
+console.log(`✅ Loaded our own keypair, the destination public key, and connected to Solana`);
 ```
 
-### 4. Ping program
+Run the script to ensure it connects, loads your keypair, and loads 
 
-Now that we've loaded our keypair, we need to connect to Solana’s Devnet. Let's create a connection:
-
-```typescript
-const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
-```
-
-Now create an async function called `sendPingTransaction()` with two parameters requiring a connection and payer’s keypair as arguments:
-
-```tsx
-async function sendPingTransaction(connection: web3.Connection, payer: web3.Keypair) { }
-```
-
-Inside this function, we need to:
-
-1. create a transaction
-2. create an instruction
-3. add the instruction to the transaction
-4. send the transaction.
-
-Remember, the most challenging piece here is including the right information in the instruction. We know the address of the program that we are calling. We also know that the program writes data to a separate account whose address we also have. Let’s add the string versions of both of those as constants at the top of the `index.ts` file:
-
-```typescript
-const PING_PROGRAM_ADDRESS = new web3.PublicKey('ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa')
-const PING_PROGRAM_DATA_ADDRESS =  new web3.PublicKey('Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod')
-```
-
-Now, in the `sendPingTransaction()` function, let’s create a new transaction, then initialize a `PublicKey` for the program account, and another for the data account.
-
-```tsx
-const transaction = new web3.Transaction()
-const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
-const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
-```
-
-Next, let’s create the instruction. Remember, the instruction needs to include the public key for the Ping program and it also needs to include an array with all the accounts that will be read from or written to. In this example program, only the data account referenced above is needed.
-
-```typescript
-const transaction = new web3.Transaction()
-
-const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
-const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
-
-const instruction = new web3.TransactionInstruction({
-  keys: [
-    {
-      pubkey: pingProgramDataId,
-      isSigner: false,
-      isWritable: true
-    },
-  ],
-  programId
-})
-```
-
-Next, let’s add the instruction to the transaction we created. Then, call `sendAndConfirmTransaction()` by passing in the connection, transaction, and payer. Finally, let’s log the result of that function call so we can look it up on the Solana Explorer.
-
-```typescript
-const transaction = new web3.Transaction()
-
-const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
-const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
-
-const instruction = new web3.TransactionInstruction({
-  keys: [
-    {
-      pubkey: pingProgramDataId,
-      isSigner: false,
-      isWritable: true
-    },
-  ],
-  programId
-})
-
-transaction.add(instruction)
-
-const signature = await web3.sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [payer]
-)
-
-console.log(`✅ Transaction completed! Signature is ${signature}`)
-```
-
-### 5. Airdrop
-
-Now run the code with `npx esrun send-ping-instruction.ts` and see if it works. You may end up with the following error in the console:
 
 ```
-> Transaction simulation failed: Attempt to debit an account but found no record of a prior credit.
+npx tsx (destination wallet address)
 ```
 
-If you get this error, it’s because your keypair is brand new and doesn’t have any SOL to cover the transaction fees. Let’s fix this by adding the following line before the call to `sendPingTransaction()`:
+### Create the transaction and run it
 
-```typescript
-await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL*1)
-```
-
-This will deposit 1 SOL into your account which you can use for testing. This won’t work on Mainnet where it would actually have value. But it's incredibly convenient for testing locally and on Devnet.
-
-### 6. Check the Solana explorer
-
-Now run the code again. It may take a moment or two, but now the code should work and you should see a long string printed to the console, like the following:
+Add the following to complete the transaction and send it:
 
 ```
-✅ Transaction completed! Signature is 55S47uwMJprFMLhRSewkoUuzUs5V6BpNfRx21MpngRUQG3AswCzCSxvQmS3WEPWDJM7bhHm3bYBrqRshj672cUSG
+console.log(`✅ Loaded our own keypair, the destination public key, and connected to Solana`);
+
+const transaction = new Transaction();
+
+const LAMPORTS_TO_SEND = 5000;
+
+const sendSolInstruction = SystemProgram.transfer({
+  fromPubkey: senderKeypair.publicKey,
+  toPubkey,
+  lamports: LAMPORTS_TO_SEND,
+});
+
+transaction.add(sendSolInstruction);
+
+const signature = await sendAndConfirmTransaction(connection, transaction, [
+  senderKeypair,
+]);
+
+console.log(`💸 Finished! Sent ${LAMPORTS_TO_SEND} to the address ${toPubkey}. `);
+console.log(`Transaction signature is ${signature}!`);
 ```
+### Experiment!
 
-Copy the transaction signature. Open a browser and go to [https://explorer.solana.com/?cluster=devnet](https://explorer.solana.com/?cluster=devnet) (the query parameter at the end of the URL will ensure that you’ll explore transactions on Devnet instead of Mainnet). Paste the signature into the search bar at the top of Solana’s Devnet explorer and hit enter. You should see all the details about the transaction. If you scroll all the way to the bottom, then you will see `Program Logs`, which show how many times the program has been pinged including your ping.
-
-![Screenshot of Solana Explorer with logs from calling the Ping program](../assets/solana-explorer-ping-result.png)
-
-Scroll around the Explorer and look at what you're seeing:
- - The **Account Input(s)** will include: 
-  - The address of your payer - being debited 5000 lamports for the transaction
-  - The program address for the ping program
-  - The data address for the ping program
- - The **Instruction** section will contain a single instructionm, with no data - the ping program is a pretty simple program, so it doesn't need any data.
- - The **Program Instruction Logs** shows the logs from the ping program.  
-
-[//]: # "TODO: these would make a good question-and-answer interactive once we have this content hosted on solana.com, and can support adding more interactive content easily."
-
-If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` in `sendPingTransaction()` to the following:
-
-```typescript
-console.log(`You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${signature}?cluster=devnet`)
-```
-
-And just like that you’re calling programs on the Solana network and writing data to chain!
-
-### Next steps
-
-In the next few lessons you’ll learn how to
-
-1. Send transactions safely from the browser instead of from running a script
-2. Add custom data to your instructions
-3. Deserialize data from the chain
+Send SOL to other students in the class.
 
 # Challenge
 
-Go ahead and create a script from scratch that will allow you to transfer SOL from one account to another on Devnet. Be sure to print out the transaction signature so you can look at it on the Solana Explorer.
+Answer the following questions:
 
-If you get stuck feel free to glance at the [solution code](https://github.com/Unboxed-Software/solana-ping-client).
+ - How much Solana did the transfer take? What is this in USD?
+
+ - Can you find your translation on https://explorer.solana.com?
+
+ - How long does the transfer take? 
+
+ - What do you think "confirmed" means?

--- a/course-structure.json
+++ b/course-structure.json
@@ -32,9 +32,14 @@
                             "lab": "Connect to Solana and check account balances"
                         },
                         {
-                            "title": "Write data to the network",
+                            "title": "Create transactions on the Solana Network",
                             "slug": "intro-to-writing-data",
                             "lab": "Make transactions and use Explorer"
+                        },
+                        {
+                            "title": "Create transactions for custom on-chain programs",
+                            "slug": "intro-to-custom-on-chain-programs",
+                            "lab": "Make transactions for a custom onchain program"
                         },
                         {
                             "title": "Interact with wallets",

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -8,7 +8,7 @@ import { readFile } from "node:fs/promises";
 
 import { marked } from "marked";
 
-const courseStucture: CourseStructure = courseStuctureUntyped;
+const courseStructure: CourseStructure = courseStuctureUntyped;
 
 const cleanContent = (content: string) => {
   // There's a bunch of metadata in the content that should really be elsewhere.
@@ -25,7 +25,7 @@ const cleanContent = (content: string) => {
 
 // See https://kit.svelte.dev/docs/load
 export async function load({ params }): Promise<PageData> {
-  const allLessons = courseStucture.tracks.flatMap((track) =>
+  const allLessons = courseStructure.tracks.flatMap((track) =>
     track.units.flatMap((module) => module.lessons),
   );
 


### PR DESCRIPTION
Would love your feedback, thoughts and suggestions here @jamesrp13. Intention here is to slow down and more deliberately have labs do labs before progressing onto next steps. Also to have students just use web3.js to check balances, then to send sol, then to introduce other on-chain apps interact with the ping counter program. 

 - refactor: make checking balance just use web3.js scripts, rather than having them build a react app. We still cover react in the 'interact with wallets' lesson, we're just focusing more on web3.js itself this early.
 - refactor: split 'writing data' lesson into two lessons with separate labs - one for transferring sol (with a lab where students get devnet sol and transfer it to each other), one for learning how to create instructions for arbitrary apps using the note program.
 - feat: explain atomicness / transactions for students not familiar with these concepts.
