### PR TITLE
fix: various minor fixes to anchor unit

### DIFF
--- a/content/es/intro-to-anchor.md
+++ b/content/es/intro-to-anchor.md
@@ -327,10 +327,10 @@ Crear un nuevo proyecto llamado `anchor-counter` ejecutando `anchor init` :
 anchor init anchor-counter
 ```
 
-A continuación, ejecute `anchor-build`
+A continuación, ejecute `anchor build`
 
 ```console
-anchor-build
+anchor build
 ```
 
 Entonces, corre `anchor keys list`

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -334,29 +334,35 @@ Next, run `anchor build`
 anchor build
 ```
 
-Then, run `anchor keys list`
+Anchor build will also generate a keypair for your new program - the keys are saved in the `target/deploy` directory.
 
-```console
-anchor keys list
-```
-
-Copy the program ID output from `anchor keys list`
-
-```
-anchor_counter: BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr
-```
-
-Then update `declare_id!` in `lib.rs`
+Open the file `lib.rs` and look at `declare_id!`: 
 
 ```rust
 declare_id!("BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr");
 ```
 
-And also update `Anchor.toml`
+Run `anchor keys sync`
 
+```console
+anchor keys sync
 ```
-[programs.localnet]
-anchor_counter = "BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr"
+
+You'll see the Anchor updates both:
+
+ - The key used in `declare_id!()` in `lib.rs` 
+ - The key in `Anchor.toml` 
+
+To match the key generated during `anchor build`:
+
+```console
+Found incorrect program id declaration in "anchor-counter/programs/anchor-counter/src/lib.rs"
+Updated to BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr
+
+Found incorrect program id declaration in Anchor.toml for the program `anchor_counter`
+Updated to BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr
+
+All program id declarations are synced.
 ```
 
 Finally, delete the default code in `lib.rs` until all that is left is the following:
@@ -364,7 +370,7 @@ Finally, delete the default code in `lib.rs` until all that is left is the follo
 ```rust
 use anchor_lang::prelude::*;
 
-declare_id!("BouTUP7a3MZLtXqMAm1NrkJSKwAjmid8abqiNjUyBJSr");
+declare_id!("your-private-key");
 
 #[program]
 pub mod anchor_counter {

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -328,10 +328,10 @@ Create a new project called `anchor-counter` by running `anchor init`:
 anchor init anchor-counter
 ```
 
-Next, run `anchor-build`
+Next, run `anchor build`
 
 ```console
-anchor-build
+anchor build
 ```
 
 Then, run `anchor keys list`

--- a/content/pda.md
+++ b/content/pda.md
@@ -24,7 +24,7 @@ Program Derived Addresses (PDAs) are account addresses designed to be signed for
 
 PDAs serve two main functions:
 
-1. Provide a deterministic way to find the address of a program-owned account
+1. Provide a deterministic way to find a given item of data for a program
 2. Authorize the program from which a PDA was derived to sign on its behalf in the same way a user may sign with their secret key
 
 In this lesson we'll focus on using PDAs to find and store data. We'll discuss signing with a PDA more thoroughly in a future lesson where we cover Cross Program Invocations (CPIs).

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -8,7 +8,7 @@ import { readFile } from "node:fs/promises";
 
 import { marked } from "marked";
 
-const courseStucture: CourseStructure = courseStuctureUntyped;
+const courseStructure: CourseStructure = courseStuctureUntyped;
 
 const cleanContent = (content: string) => {
   // There's a bunch of metadata in the content that should really be elsewhere.
@@ -25,7 +25,7 @@ const cleanContent = (content: string) => {
 
 // See https://kit.svelte.dev/docs/load
 export async function load({ params }): Promise<PageData> {
-  const allLessons = courseStucture.tracks.flatMap((track) =>
+  const allLessons = courseStructure.tracks.flatMap((track) =>
     track.units.flatMap((module) => module.lessons),
   );
 


### PR DESCRIPTION
fix: use 'anchor keys sync' to sync the keys rather than manually modifying the file
fix: an address doesn't provide a deterministic way to find an address, but rather some data
fix: anchor build not anchor-build