### PR TITLE
Typo in intro-to-custom-on-chain-programs

### DIFF
--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -193,7 +193,7 @@ Scroll around the Explorer and look at what you're seeing:
   - The address of your payer - being debited 5000 lamports for the transaction
   - The program address for the ping program
   - The data address for the ping program
- - The **Instruction** section will contain a single instructionm, with no data - the ping program is a pretty simple program, so it doesn't need any data.
+ - The **Instruction** section will contain a single instruction, with no data - the ping program is a pretty simple program, so it doesn't need any data.
  - The **Program Instruction Logs** shows the logs from the ping program.  
 
 [//]: # "TODO: these would make a good question-and-answer interactive once we have this content hosted on solana.com, and can support adding more interactive content easily."


### PR DESCRIPTION
Fix for [issue 304](https://github.com/Unboxed-Software/solana-course/issues/304).

Small typo.

Note: The numerous commits on this PR is a result of the the draft branch being behind the main branch, and I did my work on the main branch. If you'd like me to branch off the draft branch instead, I'm happy to do so.