### PR TITLE
fix anchor npm name

### DIFF
--- a/content/anchor-cpi.md
+++ b/content/anchor-cpi.md
@@ -457,8 +457,8 @@ Those are all of the changes we need to make to the program! Now, let’s update
 Start by making sure your imports nad `describe` function look like this:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { getAssociatedTokenAddress, getAccount } from "@solana/spl-token"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"

--- a/content/anchor-pdas.md
+++ b/content/anchor-pdas.md
@@ -541,8 +541,8 @@ Here we:
 - Create placeholders for tests
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { assert, expect } from "chai"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"
 

--- a/content/es/anchor-cpi.md
+++ b/content/es/anchor-cpi.md
@@ -460,8 +460,8 @@ pub fn update_movie_review(ctx: Context<UpdateMovieReview>, title: String, descr
 Comience asegurándose de que su `describe` función NAD de importaciones se vea así:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { getAssociatedTokenAddress, getAccount } from "@solana/spl-token"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"

--- a/content/es/anchor-pdas.md
+++ b/content/es/anchor-pdas.md
@@ -542,8 +542,8 @@ Aquí tenemos:
 -   Crear marcadores de posición para las pruebas
 
 ```typescript
-import * as anchor from "@project-serum/anchor";
-import { Program } from "@project-serum/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
 import { assert, expect } from "chai";
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program";
 

--- a/content/es/intro-to-anchor-frontend.md
+++ b/content/es/intro-to-anchor-frontend.md
@@ -12,14 +12,14 @@ objectives:
 # TL;DR
 
 -   An **IDL** es un archivo que representa la estructura de un programa de Solana. Los programas escritos y construidos usando Anchor generan automáticamente un IDL correspondiente. IDL son las siglas de Interface Description Language.
--   `@project-serum/anchor` es un cliente de Typescript que incluye todo lo que necesitará para interactuar con los programas de Anchor
+-   `@coral-xyz/anchor` es un cliente de Typescript que incluye todo lo que necesitará para interactuar con los programas de Anchor
 -   Un `Provider` ** objeto **de anclaje combina un `connection` a un clúster y un especificado `wallet` para habilitar la firma de transacciones
 -   Un `Program` ** objeto de **anclaje proporciona una API personalizada para interactuar con un programa específico. Crea una `Program` instancia utilizando el IDL de un programa y `Provider`.
 -   El **ancla `MethodsBuilder` ** proporciona una interfaz simple a través `Program` de instrucciones de construcción y transacciones.
 
 # Descripción general
 
-Anchor simplifica el proceso de interacción con los programas de Solana desde el cliente al proporcionar un archivo de lenguaje de descripción de interfaz (IDL) que refleja la estructura de un programa. El uso del IDL junto con la biblioteca Typescript de Anchor ( `@project-serum/anchor`) proporciona un formato simplificado para construir instrucciones y transacciones.
+Anchor simplifica el proceso de interacción con los programas de Solana desde el cliente al proporcionar un archivo de lenguaje de descripción de interfaz (IDL) que refleja la estructura de un programa. El uso del IDL junto con la biblioteca Typescript de Anchor ( `@coral-xyz/anchor`) proporciona un formato simplificado para construir instrucciones y transacciones.
 
 ```tsx
 // sends transaction
@@ -30,7 +30,7 @@ await program.methods
     .rpc();
 ```
 
-Esto funciona desde cualquier cliente Typescript, ya sea un frontend o pruebas de integración. En esta lección vamos a repasar cómo utilizar `@project-serum/anchor` para simplificar la interacción del programa del lado del cliente.
+Esto funciona desde cualquier cliente Typescript, ya sea un frontend o pruebas de integración. En esta lección vamos a repasar cómo utilizar `@coral-xyz/anchor` para simplificar la interacción del programa del lado del cliente.
 
 ## Estructura del lado del cliente de anclaje
 
@@ -110,7 +110,7 @@ Mirando más abajo en la `accounts` sección, puede ver que el programa contiene
 
 Aunque el IDL no proporciona los detalles de implementación para cada instrucción, podemos obtener una idea básica de cómo el programa en cadena espera que se construyan las instrucciones y ver la estructura de las cuentas del programa.
 
-Independientemente de cómo lo obtenga, tiene _necesidad_ un archivo IDL para interactuar con un programa que usa el `@project-serum/anchor` paquete. Para usar el IDL, deberá incluir el archivo IDL en su proyecto y luego importar el archivo.
+Independientemente de cómo lo obtenga, tiene _necesidad_ un archivo IDL para interactuar con un programa que usa el `@coral-xyz/anchor` paquete. Para usar el IDL, deberá incluir el archivo IDL en su proyecto y luego importar el archivo.
 
 ```tsx
 import idl from "./idl.json";
@@ -179,7 +179,7 @@ export interface WalletContextState {
 
 `WalletContextState` Proporciona mucha más funcionalidad en comparación con el `AnchorWallet`, pero `AnchorWallet` se requiere para configurar el `Provider` objeto.
 
-Para crear el `Provider` objeto `AnchorProvider` desde el que se usa `@project-serum/anchor`.
+Para crear el `Provider` objeto `AnchorProvider` desde el que se usa `@coral-xyz/anchor`.
 
 El `AnchorProvider` constructor tiene tres parámetros:
 
@@ -191,7 +191,7 @@ Una vez que haya creado el `Provider` objeto, configúrelo como proveedor predet
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react";
-import { AnchorProvider, setProvider } from "@project-serum/anchor";
+import { AnchorProvider, setProvider } from "@coral-xyz/anchor";
 
 const { connection } = useConnection();
 const wallet = useAnchorWallet();
@@ -209,7 +209,7 @@ Una vez que tenga el IDL y un proveedor, puede crear una instancia de `Program`.
 
 El `Program`  objeto crea una API personalizada que puede usar para interactuar con un programa de Solana. Esta API es la ventanilla única para todo lo relacionado con la comunicación con los programas en cadena. Entre otras cosas, puede enviar transacciones, obtener cuentas deserializadas, decodificar datos de instrucciones, suscribirse a cambios en la cuenta y escuchar eventos. Puedes aprender más sobre la `Program` clase[here](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-Para crear el `Program` objeto, primero importa `Program` y `Idl` desde `@project-serum/anchor`. `Idl` es un tipo que puedes usar cuando trabajas con Typescript.
+Para crear el `Program` objeto, primero importa `Program` y `Idl` desde `@coral-xyz/anchor`. `Idl` es un tipo que puedes usar cuando trabajas con Typescript.
 
 A continuación, especifique `programId` la del programa. Tenemos que indicar explícitamente el `programId` ya que puede haber múltiples programas con la misma estructura IDL (es decir, si el mismo programa se implementa varias veces utilizando diferentes direcciones). Al crear el `Program` objeto, `Provider` se utiliza el valor predeterminado si no se especifica explícitamente uno.
 
@@ -223,7 +223,7 @@ import {
     Idl,
     AnchorProvider,
     setProvider,
-} from "@project-serum/anchor";
+} from "@coral-xyz/anchor";
 
 const { connection } = useConnection();
 const wallet = useAnchorWallet();

--- a/content/es/intro-to-anchor.md
+++ b/content/es/intro-to-anchor.md
@@ -506,8 +506,8 @@ Ejecutar `anchor build` para construir el programa.
 Las pruebas de anclaje son típicamente pruebas de integración de Typescript que utilizan el marco de prueba mocha. Aprenderemos más sobre las pruebas más adelante, pero por ahora navegue `anchor-counter.ts` y reemplace el código de prueba predeterminado con lo siguiente:
 
 ```typescript
-import * as anchor from "@project-serum/anchor";
-import { Program } from "@project-serum/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
 import { expect } from "chai";
 import { AnchorCounter } from "../target/types/anchor_counter";
 

--- a/content/es/reinitialization-attacks.md
+++ b/content/es/reinitialization-attacks.md
@@ -221,8 +221,8 @@ Dado que no hay comprobaciones de que los datos de la cuenta no hayan sido ya in
 
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { Initialization } from "../target/types/initialization"
 

--- a/content/es/type-cosplay.md
+++ b/content/es/type-cosplay.md
@@ -258,8 +258,8 @@ Ahora en su `programs` carpeta tendrá dos programas. Ejecute `anchor keys list`
 A continuación, actualice la configuración del archivo de prueba para incluir el nuevo programa y dos nuevos pares de teclas para las cuentas que iniciaremos para el nuevo programa.
 
 ```tsx
-import * as anchor from "@project-serum/anchor";
-import { Program } from "@project-serum/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
 import { TypeCosplay } from "../target/types/type_cosplay";
 import { TypeChecked } from "../target/types/type_checked";
 import { expect } from "chai";

--- a/content/fil/anchor-cpi.md
+++ b/content/fil/anchor-cpi.md
@@ -456,8 +456,8 @@ Iyan ang lahat ng mga pagbabagong kailangan nating gawin sa programa! Ngayon, i-
 Magsimula sa pamamagitan ng pagtiyak na ganito ang hitsura ng iyong pag-import nad `describe` function:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { getAssociatedTokenAddress, getAccount } from "@solana/spl-token"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"

--- a/content/fil/anchor-pdas.md
+++ b/content/fil/anchor-pdas.md
@@ -541,8 +541,8 @@ Dito tayo:
 - Lumikha ng mga placeholder para sa mga pagsubok
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { assert, expect } from "chai"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"
 

--- a/content/fil/intro-to-anchor-frontend.md
+++ b/content/fil/intro-to-anchor-frontend.md
@@ -12,14 +12,14 @@ objectives:
 # TL;DR
 
 - Ang **IDL** ay isang file na kumakatawan sa istruktura ng isang Solana program. Ang mga program na isinulat at binuo gamit ang Anchor ay awtomatikong bumubuo ng kaukulang IDL. Ang ibig sabihin ng IDL ay Interface Description Language.
-- Ang `@project-serum/anchor` ay isang Typescript client na kinabibilangan ng lahat ng kakailanganin mo para makipag-ugnayan sa mga Anchor program
+- Ang `@coral-xyz/anchor` ay isang Typescript client na kinabibilangan ng lahat ng kakailanganin mo para makipag-ugnayan sa mga Anchor program
 - Isang bagay na **Anchor `Provider`** ang isang `koneksyon` sa isang cluster at isang tinukoy na `wallet` upang paganahin ang pag-sign ng transaksyon
 - Isang bagay na **Anchor `Program`** ay nagbibigay ng custom na API upang makipag-ugnayan sa isang partikular na program. Lumilikha ka ng instance ng `Program` gamit ang IDL at `Provider` ng isang program.
 - Ang **Anchor `MethodsBuilder`** ay nagbibigay ng isang simpleng interface sa pamamagitan ng `Program` para sa mga tagubilin sa pagbuo at mga transaksyon
 
 # Overview
 
-Pinapasimple ng Anchor ang proseso ng pakikipag-ugnayan sa mga program ng Solana mula sa kliyente sa pamamagitan ng pagbibigay ng file ng Interface Description Language (IDL) na sumasalamin sa istruktura ng isang programa. Ang paggamit ng IDL kasabay ng Anchor's Typescript library (`@project-serum/anchor`) ay nagbibigay ng pinasimpleng format para sa pagbuo ng mga tagubilin at transaksyon.
+Pinapasimple ng Anchor ang proseso ng pakikipag-ugnayan sa mga program ng Solana mula sa kliyente sa pamamagitan ng pagbibigay ng file ng Interface Description Language (IDL) na sumasalamin sa istruktura ng isang programa. Ang paggamit ng IDL kasabay ng Anchor's Typescript library (`@coral-xyz/anchor`) ay nagbibigay ng pinasimpleng format para sa pagbuo ng mga tagubilin at transaksyon.
 
 ```tsx
 // sends transaction
@@ -30,7 +30,7 @@ await program.methods
   .rpc()
 ```
 
-Gumagana ito mula sa alinmang Typescript client, ito man ay isang frontend o integration test. Sa araling ito, tatalakayin natin kung paano gamitin ang `@project-serum/anchor` upang pasimplehin ang iyong pakikipag-ugnayan sa programa sa panig ng kliyente.
+Gumagana ito mula sa alinmang Typescript client, ito man ay isang frontend o integration test. Sa araling ito, tatalakayin natin kung paano gamitin ang `@coral-xyz/anchor` upang pasimplehin ang iyong pakikipag-ugnayan sa programa sa panig ng kliyente.
 
 ## Anchor client-side structure
 
@@ -110,7 +110,7 @@ Kung titingnan sa ibaba ang seksyong `account`, makikita mo na ang program ay na
 
 Bagama't hindi ibinibigay ng IDL ang mga detalye ng pagpapatupad para sa bawat pagtuturo, makakakuha tayo ng pangunahing ideya kung paano inaasahan ng on-chain program ang mga tagubilin na mabuo at makita ang istruktura ng mga account ng programa.
 
-Hindi alintana kung paano mo ito makuha, *kailangan mo* ng IDL file para makipag-ugnayan sa isang program gamit ang `@project-serum/anchor` package. Upang magamit ang IDL, kakailanganin mong isama ang IDL file sa iyong proyekto at pagkatapos ay i-import ang file.
+Hindi alintana kung paano mo ito makuha, *kailangan mo* ng IDL file para makipag-ugnayan sa isang program gamit ang `@coral-xyz/anchor` package. Upang magamit ang IDL, kakailanganin mong isama ang IDL file sa iyong proyekto at pagkatapos ay i-import ang file.
 
 ```tsx
 import idl from "./idl.json"
@@ -179,7 +179,7 @@ export interface WalletContextState {
 
 Ang `WalletContextState` ay nagbibigay ng mas maraming functionality kumpara sa `AnchorWallet`, ngunit ang `AnchorWallet` ay kinakailangan upang i-set up ang `Provider` object.
 
-Upang gawin ang object na `Provider` ginagamit mo ang `AnchorProvider` mula sa `@project-serum/anchor`.
+Upang gawin ang object na `Provider` ginagamit mo ang `AnchorProvider` mula sa `@coral-xyz/anchor`.
 
 Ang `AnchorProvider` constructor ay tumatagal ng tatlong parameter:
 
@@ -191,7 +191,7 @@ Kapag nagawa mo na ang object na `Provider`, itatakda mo ito bilang default prov
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
-import { AnchorProvider, setProvider } from "@project-serum/anchor"
+import { AnchorProvider, setProvider } from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()
@@ -209,7 +209,7 @@ Kapag mayroon ka nang IDL at isang provider, maaari kang lumikha ng isang instan
 
 Gumagawa ang object ng `Program` ng custom na API na magagamit mo para makipag-ugnayan sa isang Solana program. Ang API na ito ay ang one stop shop para sa lahat ng bagay na nauugnay sa pakikipag-ugnayan sa mga on-chain na programa. Sa iba pang mga bagay, maaari kang magpadala ng mga transaksyon, kumuha ng mga deserialized na account, mag-decode ng data ng pagtuturo, mag-subscribe sa mga pagbabago sa account, at makinig sa mga kaganapan. Maaari ka ring [matuto nang higit pa tungkol sa klase ng `Program`](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-Upang gawin ang object na `Program`, i-import muna ang `Program` at `Idl` mula sa `@project-serum/anchor`. Ang `Idl` ay isang uri na magagamit mo kapag nagtatrabaho sa Typescript.
+Upang gawin ang object na `Program`, i-import muna ang `Program` at `Idl` mula sa `@coral-xyz/anchor`. Ang `Idl` ay isang uri na magagamit mo kapag nagtatrabaho sa Typescript.
 
 Susunod, tukuyin ang `programId` ng program. Kailangan nating tahasan na sabihin ang `programId` dahil maaaring mayroong maraming mga program na may parehong istraktura ng IDL (ibig sabihin, kung ang parehong programa ay na-deploy nang maraming beses gamit ang iba't ibang mga address). Kapag nililikha ang object na `Program`, ginagamit ang default na `Provider` kung ang isa ay hindi tahasang tinukoy.
 
@@ -223,7 +223,7 @@ import {
   Idl,
   AnchorProvider,
   setProvider,
-} from "@project-serum/anchor"
+} from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()

--- a/content/fil/intro-to-anchor.md
+++ b/content/fil/intro-to-anchor.md
@@ -507,8 +507,8 @@ Patakbuhin ang `anchor build` upang buuin ang program.
 Ang mga anchor test ay karaniwang mga Typescript integration test na gumagamit ng mocha test framework. Matututunan namin ang higit pa tungkol sa pagsubok sa ibang pagkakataon, ngunit sa ngayon ay mag-navigate sa `anchor-counter.ts` at palitan ang default na test code ng mga sumusunod:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { AnchorCounter } from "../target/types/anchor_counter"
 

--- a/content/fil/reinitialization-attacks.md
+++ b/content/fil/reinitialization-attacks.md
@@ -214,8 +214,8 @@ Kasama sa test file ang setup para gumawa ng account sa pamamagitan ng paggamit 
 Dahil walang mga pagsusuri sa pag-verify na ang data ng account ay hindi pa nasisimulan, ang pagtuturo ng `insecure_initialization` ay matagumpay na makukumpleto sa parehong pagkakataon, sa kabila ng pangalawang invocation na nagbibigay ng *ibang* awtoridad na account.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { Initialization } from "../target/types/initialization"
 

--- a/content/fil/type-cosplay.md
+++ b/content/fil/type-cosplay.md
@@ -258,8 +258,8 @@ Ngayon sa iyong `programs` folder magkakaroon ka ng dalawang program. Patakbuhin
 Susunod, i-update ang setup ng test file para isama ang bagong program at dalawang bagong keypair para sa mga account na sisimulan namin para sa bagong program.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { TypeCosplay } from "../target/types/type_cosplay"
 import { TypeChecked } from "../target/types/type_checked"
 import { expect } from "chai"

--- a/content/intro-to-anchor-frontend.md
+++ b/content/intro-to-anchor-frontend.md
@@ -12,14 +12,14 @@ objectives:
 # Summary
 
 - An **IDL** is a file representing the structure of a Solana program. Programs written and built using Anchor automatically generate a corresponding IDL. IDL stands for Interface Description Language.
-- `@project-serum/anchor` is a Typescript client that includes everything you’ll need to interact with Anchor programs
+- `@coral-xyz/anchor` is a Typescript client that includes everything you’ll need to interact with Anchor programs
 - An **Anchor `Provider`** object combines a `connection` to a cluster and a specified `wallet` to enable transaction signing
 - An **Anchor `Program`** object provides a custom API to interact with a specific program. You create a `Program` instance using a program's IDL and `Provider`.
 - The **Anchor `MethodsBuilder`** provides a simple interface through `Program` for building instructions and transactions
 
 # Overview
 
-Anchor simplifies the process of interacting with Solana programs from the client by providing an Interface Description Language (IDL) file that reflects the structure of a program. Using the IDL in conjunction with Anchor's Typescript library (`@project-serum/anchor`) provides a simplified format for building instructions and transactions.
+Anchor simplifies the process of interacting with Solana programs from the client by providing an Interface Description Language (IDL) file that reflects the structure of a program. Using the IDL in conjunction with Anchor's Typescript library (`@coral-xyz/anchor`) provides a simplified format for building instructions and transactions.
 
 ```tsx
 // sends transaction
@@ -30,7 +30,7 @@ await program.methods
   .rpc()
 ```
 
-This works from any Typescript client, whether it's a frontend or integration tests. In this lesson we'll go over how to use `@project-serum/anchor` to simplify your client-side program interaction.
+This works from any Typescript client, whether it's a frontend or integration tests. In this lesson we'll go over how to use `@coral-xyz/anchor` to simplify your client-side program interaction.
 
 ## Anchor client-side structure
 
@@ -110,7 +110,7 @@ Looking further down at the `accounts` section, you can see that the program con
 
 Although the IDL does not provide the implementation details for each instruction, we can get a basic idea of how the onchain program expects instructions to be constructed and see the structure of the program accounts.
 
-Regardless of how you get it, you *need* an IDL file to interact with a program using the `@project-serum/anchor` package. To use the IDL, you'll need to include the IDL file in your project and then import the file.
+Regardless of how you get it, you *need* an IDL file to interact with a program using the `@coral-xyz/anchor` package. To use the IDL, you'll need to include the IDL file in your project and then import the file.
 
 ```tsx
 import idl from "./idl.json"
@@ -179,7 +179,7 @@ export interface WalletContextState {
 
 The `WalletContextState` provides much more functionality compared to the `AnchorWallet`, but the `AnchorWallet` is required to set up the `Provider` object.
 
-To create the `Provider` object you use `AnchorProvider` from `@project-serum/anchor`.
+To create the `Provider` object you use `AnchorProvider` from `@coral-xyz/anchor`.
 
 The `AnchorProvider` constructor takes three parameters:
 
@@ -191,7 +191,7 @@ Once you’ve create the `Provider` object, you then set it as the default provi
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
-import { AnchorProvider, setProvider } from "@project-serum/anchor"
+import { AnchorProvider, setProvider } from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()
@@ -209,7 +209,7 @@ Once you have the IDL and a provider, you can create an instance of `Program`. T
 
 The `Program` object creates a custom API you can use to interact with a Solana program. This API is the one stop shop for all things related to communicating with onchain programs. Among other things, you can send transactions, fetch deserialized accounts, decode instruction data, subscribe to account changes, and listen to events. You can also [learn more about the `Program` class](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-To create the `Program` object, first import `Program` and `Idl` from `@project-serum/anchor`. `Idl` is a type you can used when working with Typescript.
+To create the `Program` object, first import `Program` and `Idl` from `@coral-xyz/anchor`. `Idl` is a type you can used when working with Typescript.
 
 Next, specify the `programId` of the program. We have to explicitly state the `programId` since there can be multiple programs with the same IDL structure (i.e. if the same program is deployed multiple times using different addresses). When creating the `Program` object, the default `Provider` is used if one is not explicitly specified.
 
@@ -223,7 +223,7 @@ import {
   Idl,
   AnchorProvider,
   setProvider,
-} from "@project-serum/anchor"
+} from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -514,8 +514,8 @@ Run `anchor build` to build the program.
 Anchor tests are typically Typescript integration tests that use the mocha test framework. We'll learn more about testing later, but for now navigate to `anchor-counter.ts` and replace the default test code with the following:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { AnchorCounter } from "../target/types/anchor_counter"
 

--- a/content/pt_br/anchor-cpi.md
+++ b/content/pt_br/anchor-cpi.md
@@ -456,8 +456,8 @@ Essas são todas as alterações que precisamos fazer no programa! Agora, vamos 
 Comece certificando-se de que suas importações e a função `describe` tenham a seguinte aparência:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { getAssociatedTokenAddress, getAccount } from "@solana/spl-token"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"

--- a/content/pt_br/anchor-pdas.md
+++ b/content/pt_br/anchor-pdas.md
@@ -541,8 +541,8 @@ Aqui nós:
 - Criamos espaços reservados para os testes
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { assert, expect } from "chai"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"
 

--- a/content/pt_br/intro-to-anchor-frontend.md
+++ b/content/pt_br/intro-to-anchor-frontend.md
@@ -12,14 +12,14 @@ objectives:
 # RESUMO
 
 - Uma **IDL** é um arquivo que representa a estrutura de um programa Solana. Os programas escritos e criados com o Anchor geram automaticamente uma IDL correspondente. IDL significa Interface Description Language (linguagem de descrição de interface).
-- O `@project-serum/anchor` é um cliente Typescript que inclui tudo o que você precisa para interagir com os programas Anchor
+- O `@coral-xyz/anchor` é um cliente Typescript que inclui tudo o que você precisa para interagir com os programas Anchor
 - Um objeto **Anchor `Provider`** combina uma `connection` a um cluster e uma `wallet` especificada para permitir a assinatura de transações
 - Um objeto **Anchor `Program`** fornece uma API personalizada para interagir com um programa específico. Você cria uma instância `Program` usando a IDL e o `Provider` de um programa.
 - O **Anchor `MethodsBuilder`** fornece uma interface simples por meio do `Program` para criar instruções e transações
 
 # Visão Geral
 
-O Anchor simplifica o processo de interação com os programas Solana a partir do cliente, fornecendo um arquivo IDL (Linguagem de descrição de interface) que reflete a estrutura de um programa. O uso da IDL em conjunto com a biblioteca Typescript do Anchor (`@project-serum/anchor`) fornece um formato simplificado para a criação de instruções e transações.
+O Anchor simplifica o processo de interação com os programas Solana a partir do cliente, fornecendo um arquivo IDL (Linguagem de descrição de interface) que reflete a estrutura de um programa. O uso da IDL em conjunto com a biblioteca Typescript do Anchor (`@coral-xyz/anchor`) fornece um formato simplificado para a criação de instruções e transações.
 
 ```tsx
 // envia a transação
@@ -30,7 +30,7 @@ await program.methods
   .rpc()
 ```
 
-Isso funciona de qualquer cliente Typescript, seja em um frontend ou testes de integração. Nesta lição, veremos como usar o `@project-serum/anchor` para simplificar a interação de seu programa no lado do cliente.
+Isso funciona de qualquer cliente Typescript, seja em um frontend ou testes de integração. Nesta lição, veremos como usar o `@coral-xyz/anchor` para simplificar a interação de seu programa no lado do cliente.
 
 ## Estrutura Anchor do lado do cliente
 
@@ -110,7 +110,7 @@ Observando a seção `accounts`, é possível ver que o programa contém um tipo
 
 Embora a IDL não forneça os detalhes de implementação de cada instrução, podemos ter uma ideia básica de como o programa on-chain espera que as instruções sejam construídas e podemos ver a estrutura das contas do programa.
 
-Independentemente de como você o obtenha, você precisa de um arquivo IDL para interagir com um programa que use o pacote `@project-serum/anchor`. Para usar a IDL, você precisará incluir o arquivo IDL em seu projeto e, em seguida, importar o arquivo.
+Independentemente de como você o obtenha, você precisa de um arquivo IDL para interagir com um programa que use o pacote `@coral-xyz/anchor`. Para usar a IDL, você precisará incluir o arquivo IDL em seu projeto e, em seguida, importar o arquivo.
 
 ```tsx
 import idl from "./idl.json"
@@ -179,7 +179,7 @@ export interface WalletContextState {
 
 O `WalletContextState` oferece muito mais funcionalidades em comparação com o `AnchorWallet`, mas o `AnchorWallet` é necessário para configurar o objeto `Provider`.
 
-Para criar o objeto `Provider`, você usa o `AnchorProvider` do `@project-serum/anchor`.
+Para criar o objeto `Provider`, você usa o `AnchorProvider` do `@coral-xyz/anchor`.
 
 O construtor `AnchorProvider` recebe três parâmetros:
 
@@ -191,7 +191,7 @@ Depois de criar o objeto `Provider`, você o define como o provedor padrão usan
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
-import { AnchorProvider, setProvider } from "@project-serum/anchor"
+import { AnchorProvider, setProvider } from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()
@@ -209,7 +209,7 @@ Depois de ter a IDL e um provedor, você pode criar uma instância do `Program`.
 
 O objeto `Program` cria uma API personalizada que você pode usar para interagir com um programa Solana. Essa API é o ponto de parada único para todas as coisas relacionadas à comunicação com programas on-chain. Entre outras coisas, você pode enviar transações, buscar contas desserializadas, decodificar dados de instrução, assinar alterações de conta e ouvir eventos. Você também pode [aprender mais sobre a classe do `Program`](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-Para criar o objeto `Program`, primeiro importe `Program` e `Idl` de `@project-serum/anchor`. O `Idl` é um tipo que pode ser usado quando se trabalha com Typescript.
+Para criar o objeto `Program`, primeiro importe `Program` e `Idl` de `@coral-xyz/anchor`. O `Idl` é um tipo que pode ser usado quando se trabalha com Typescript.
 
 Em seguida, especifique o `programId` do programa. Temos que declarar explicitamente o `programId`, pois pode haver vários programas com a mesma estrutura IDL (ou seja, se o mesmo programa for implantado várias vezes usando endereços diferentes). Ao criar o objeto `Program`, o `Provider` padrão é usado se não for explicitamente especificado.
 
@@ -223,7 +223,7 @@ import {
   Idl,
   AnchorProvider,
   setProvider,
-} from "@project-serum/anchor"
+} from "@coral-xyz/anchor"
 
 const { connection } = useConnection()
 const wallet = useAnchorWallet()

--- a/content/pt_br/intro-to-anchor.md
+++ b/content/pt_br/intro-to-anchor.md
@@ -508,8 +508,8 @@ Execute `anchor build` para construir o programa.
 Os testes do Anchor são tipicamente testes de integração em Typescript que usam o framework de teste Mocha. Aprenderemos mais sobre testes mais tarde, mas por agora navegue até `anchor-counter.ts` e substitua o código de teste padrão pelo seguinte:
 
 ```typescript
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { AnchorCounter } from "../target/types/anchor_counter"
 

--- a/content/pt_br/reinitialization-attacks.md
+++ b/content/pt_br/reinitialization-attacks.md
@@ -214,8 +214,8 @@ O arquivo de teste inclui a configuração para criar uma conta invocando o prog
 Como não há verificações para confirmar se os dados da conta já foram inicializados, a instrução `insecure_initialization` será concluída com êxito nas duas vezes, apesar de a segunda invocação fornecer uma conta de autoridade *diferente*.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { Initialization } from "../target/types/initialization"
 

--- a/content/pt_br/type-cosplay.md
+++ b/content/pt_br/type-cosplay.md
@@ -258,8 +258,8 @@ Agora, na sua pasta `programs`, você terá dois programas. Execute `anchor keys
 Em seguida, atualize a configuração do arquivo de teste para incluir o novo programa e dois novos pares de chaves para as contas que inicializaremos para o novo programa.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { TypeCosplay } from "../target/types/type_cosplay"
 import { TypeChecked } from "../target/types/type_checked"
 import { expect } from "chai"

--- a/content/reinitialization-attacks.md
+++ b/content/reinitialization-attacks.md
@@ -214,8 +214,8 @@ The test file includes the setup to create an account by invoking the system pro
 Since there are no checks the verify that the account data has not already been initialized, the `insecure_initialization` instruction will complete successfully both times, despite the second invocation providing a *different* authority account.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { expect } from "chai"
 import { Initialization } from "../target/types/initialization"
 

--- a/content/type-cosplay.md
+++ b/content/type-cosplay.md
@@ -258,8 +258,8 @@ Now in your `programs` folder you will have two programs. Run `anchor keys list`
 Next, update the test file's setup to include the new program and two new keypairs for the accounts we'll be initializing for the new program.
 
 ```tsx
-import * as anchor from "@project-serum/anchor"
-import { Program } from "@project-serum/anchor"
+import * as anchor from "@coral-xyz/anchor"
+import { Program } from "@coral-xyz/anchor"
 import { TypeCosplay } from "../target/types/type_cosplay"
 import { TypeChecked } from "../target/types/type_checked"
 import { expect } from "chai"


### PR DESCRIPTION
Merging this immediately. https://www.npmjs.com/package/@project-serum/anchor is a year old, out of date and Project Serum no longer exists.

