### PR TITLE
Fix code example errors and changes per style guide

### DIFF
--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -109,7 +109,7 @@ const newBalance = await requestAndConfirmAirdropIfRequired(
 );
 ```
 
-This will connect to the Solana Devnet and request some test Lamports if needed.
+This will connect to Solana Devnet and request some test Lamports if needed.
 
 ### 2. Ping program
 

--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -71,7 +71,7 @@ console.log(`✅ Success! Transaction signature is: ${signature}`);
 
 ![Screenshot of Solana Explorer set to Devnet](../assets/solana-explorer-devnet.png)
 
-All transactions on the blockchain are publicly viewable on the [Solana Explorer](http://explorer.solana.com). For example, you could take the signature returned by `sendAndConfirmTransaction()` in the example above, search for that signature in the Solana Explorer, then see:
+All transactions on the blockchain are publicly viewable on [Solana Explorer](http://explorer.solana.com). For example, you could take the signature returned by `sendAndConfirmTransaction()` in the example above, search for that signature in Solana Explorer, then see:
 
 - when it occurred
 - which block it was included in
@@ -109,7 +109,7 @@ const newBalance = await requestAndConfirmAirdropIfRequired(
 );
 ```
 
-This will connect to the Solana Devnet and load some Lamports if needed.
+This will connect to the Solana Devnet and request some test Lamports if needed.
 
 ### 2. Ping program
 
@@ -154,7 +154,7 @@ const instruction = new web3.TransactionInstruction({
 })
 ```
 
-Next, let’s add the instruction to the transaction we created. Then, call `sendAndConfirmTransaction()` by passing in the connection, transaction, and payer. Finally, let’s log the result of that function call so we can look it up on the Solana Explorer.
+Next, let’s add the instruction to the transaction we created. Then, call `sendAndConfirmTransaction()` by passing in the connection, transaction, and payer. Finally, let’s log the result of that function call so we can look it up on Solana Explorer.
 
 ```typescript
 transaction.add(instruction)
@@ -168,7 +168,7 @@ const signature = await web3.sendAndConfirmTransaction(
 console.log(`✅ Transaction completed! Signature is ${signature}`)
 ```
 
-### 3. Run the ping client and check the Solana explorer
+### 3. Run the ping client and check Solana Explorer
 
 Now run the code with the following command:
 
@@ -186,7 +186,7 @@ Copy the transaction signature. Open a browser and go to [https://explorer.solan
 
 ![Screenshot of Solana Explorer with logs from calling the Ping program](../assets/solana-explorer-ping-result.png)
 
-Scroll around the Explorer and look at what you're seeing:
+Scroll around the explorer and look at what you're seeing:
 - The **Account Input(s)** will include:
   - The address of your payer - being debited 5000 lamports for the transaction
   - The program address for the ping program
@@ -196,10 +196,10 @@ Scroll around the Explorer and look at what you're seeing:
 
 [//]: # "TODO: these would make a good question-and-answer interactive once we have this content hosted on solana.com, and can support adding more interactive content easily."
 
-If you want to make it easier to look at the Solana Explorer for transactions in the future, simply change your `console.log` to the following:
+If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` to the following:
 
 ```typescript
-console.log(`You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${signature}?cluster=devnet`)
+console.log(`You can view your transaction on Solana Explorer at:\nhttps://explorer.solana.com/tx/${signature}?cluster=devnet`)
 ```
 
 And just like that you’re calling programs on the Solana network and writing data to chain!
@@ -212,7 +212,7 @@ In the next few lessons you’ll learn how to
 
 # Challenge
 
-Go ahead and create a script from scratch that will allow you to transfer SOL from one account to another on Devnet. Be sure to print out the transaction signature so you can look at it on the Solana Explorer.
+Go ahead and create a script from scratch that will allow you to transfer SOL from one account to another on Devnet. Be sure to print out the transaction signature so you can look at it on Solana Explorer.
 
 If you get stuck feel free to glance at the [solution code](https://github.com/Unboxed-Software/solana-ping-client).
 

--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -11,7 +11,7 @@ Solana has multiple onchain programs you can use. Instructions that use these pr
 # Overview
 ### Instructions
 
-In previous chapters, we used `SystemProgram.transfer()` function to create and instruction to send Solana. 
+In previous chapters, we used the `SystemProgram.transfer()` function to create an instruction to send SOL.
 
 When working with non-native programs, however, you’ll need to be more specific about creating instructions that are structured to match the corresponding program.
 
@@ -80,22 +80,22 @@ All transactions on the blockchain are publicly viewable on the [Solana Explorer
 
 ![Screenshot of Solana Explorer with details about a transaction](../assets/solana-explorer-transaction-overview.png)
 
-# Lab - writing transactions for the ping counter program 
+# Lab
+### Writing transactions for the ping counter program
 
-We’re going to create a script to ping an onchain program that increments a counter each time it has been pinged. This program exists on the Solana Devnet at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores it's data in a specific account at the address `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
+We’re going to create a script to ping an onchain program that increments a counter each time it has been pinged. This program exists on the Solana Devnet at address `ChT1B39WKLS8qUrkLvFDXMhEJ4F1XZzwUNHUt4AU9aVa`. The program stores its data in a specific account at the address `Ah9K7dQ8EHaZqcAsgBW8w37yN2eAy3koFmUn4x3CJtod`.
 
-![Solana stores programs and data in seperate accounts](../assets/pdas-note-taking-program.svg)
+Solana stores programs and data in separate accounts.
 
 ### 1. Basic scaffolding
 
 We'll start by using the same packages and `.env` file we made earlier in [intro to writing data](./intro-to-writing-data).
 
-Call the file `send-ping-transaction.ts`:
+Name the file `send-ping-transaction.ts`:
 
 ```typescript
 import * as web3 from "@solana/web3.js";
 import "dotenv/config"
-import base58 from "bs58";
 import { getKeypairFromEnvironment, requestAndConfirmAirdropIfRequired } from "@solana-developers/helpers";
 
 const payer = getKeypairFromEnvironment('SECRET_KEY')
@@ -104,13 +104,12 @@ const connection = new web3.Connection(web3.clusterApiUrl('devnet'))
 const newBalance = await requestAndConfirmAirdropIfRequired(
   connection,
   payer.publicKey,
-  1 * LAMPORTS_PER_SOL,
-  0.5 * LAMPORTS_PER_SOL,
+  1 * web3.LAMPORTS_PER_SOL,
+  0.5 * web3.LAMPORTS_PER_SOL,
 );
-
 ```
 
-This will connect to Solana and load some Lamports if needed.
+This will connect to the Solana Devnet and load some Lamports if needed.
 
 ### 2. Ping program
 
@@ -119,7 +118,7 @@ Now let's talk to the Ping program! To do this, we need to:
 1. create a transaction
 2. create an instruction
 3. add the instruction to the transaction
-4. send the transaction.
+4. send the transaction
 
 Remember, the most challenging piece here is including the right information in the instructions. We know the address of the program that we are calling. We also know that the program writes data to a separate account whose address we also have. Let’s add the string versions of both of those as constants at the top of the file:
 
@@ -140,7 +139,6 @@ Next, let’s create the instruction. Remember, the instruction needs to include
 
 ```typescript
 const transaction = new web3.Transaction()
-
 const programId = new web3.PublicKey(PING_PROGRAM_ADDRESS)
 const pingProgramDataId = new web3.PublicKey(PING_PROGRAM_DATA_ADDRESS)
 
@@ -172,13 +170,13 @@ console.log(`✅ Transaction completed! Signature is ${signature}`)
 
 ### 3. Run the ping client and check the Solana explorer
 
-Now run the code again. 
+Now run the code with the following command:
 
 ```
 npx esrun send-ping-transaction.ts
 ```
 
-It may take a moment or two, but now the code should work and you should see a long string printed to the console, like the following:
+It may take a moment or two but you should see a long string printed to the console, like the following:
 
 ```
 ✅ Transaction completed! Signature is 55S47uwMJprFMLhRSewkoUuzUs5V6BpNfRx21MpngRUQG3AswCzCSxvQmS3WEPWDJM7bhHm3bYBrqRshj672cUSG
@@ -189,16 +187,16 @@ Copy the transaction signature. Open a browser and go to [https://explorer.solan
 ![Screenshot of Solana Explorer with logs from calling the Ping program](../assets/solana-explorer-ping-result.png)
 
 Scroll around the Explorer and look at what you're seeing:
- - The **Account Input(s)** will include: 
+- The **Account Input(s)** will include:
   - The address of your payer - being debited 5000 lamports for the transaction
   - The program address for the ping program
   - The data address for the ping program
- - The **Instruction** section will contain a single instruction with no data - the ping program is a pretty simple program, so it doesn't need any data.
- - The **Program Instruction Logs** shows the logs from the ping program.  
+- The **Instruction** section will contain a single instruction with no data - the ping program is a pretty simple program, so it doesn't need any data.
+- The **Program Instruction Logs** shows the logs from the ping program.
 
 [//]: # "TODO: these would make a good question-and-answer interactive once we have this content hosted on solana.com, and can support adding more interactive content easily."
 
-If you want to make it easier to look at Solana Explorer for transactions in the future, simply change your `console.log` to the following:
+If you want to make it easier to look at the Solana Explorer for transactions in the future, simply change your `console.log` to the following:
 
 ```typescript
 console.log(`You can view your transaction on the Solana Explorer at:\nhttps://explorer.solana.com/tx/${signature}?cluster=devnet`)


### PR DESCRIPTION
Summary of the changes I have made as suggested here https://github.com/Unboxed-Software/solana-course/issues/324:
- Sundry editorial changes per style guide.
- Removed redundant base58 import in code example
- Removed unreferenced 'note taking program' graphic
- Added required web3 prefix to LAMPORTS_PER_SOL constant in code example
- Removed text related to running code 'again' as it hasn't been run before
- Fixed indenting for items listed under 'Account Input(s)'
