### PR TITLE
refactor: rename 'overview' to 'lesson'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Each **Lesson** is a block of added understanding, starting from scratch and bui
 
 Lessons should follow the format:
 
- - **Overview** section is a conceptual overview. The equivalent would be when a teacher in a classroom says "don't do this yet, just watch.". The overview is intentionally not meant to be something readers code along with.
+ - **Lesson** section is the main body of the lesson, explaining the new concepts. The equivalent would be when a teacher in a classroom says "don't do this yet, just watch.". This section is intentionally not meant to be something readers code along with.
 
  - **Lab** section is when students code along and should follow a step-by-step process.
 

--- a/content/account-data-matching.md
+++ b/content/account-data-matching.md
@@ -19,7 +19,7 @@ objectives:
     
 - In Anchor, you can use `constraint` to checks whether the given expression evaluates to true. Alternatively, you can use `has_one` to check that a target account field stored on the account matches the key of an account in the `Accounts` struct.
 
-# Overview
+# Lesson
 
 Account data matching refers to data validation checks used to verify the data stored on an account matches an expected value. Data validation checks provide a way to include additional constraints to ensure the appropriate accounts are passed into an instruction. 
 

--- a/content/anchor-cpi.md
+++ b/content/anchor-cpi.md
@@ -14,7 +14,7 @@ objectives:
 - If you do not have access to CPI helper functions, you can still use `invoke` and `invoke_signed` directly
 - The **`error_code`** attribute macro is used to create custom Anchor Errors
 
-# Overview
+# Lesson
 
 If you think back to the [first CPI lesson](cpi), you'll remember that constructing CPIs can get tricky with vanilla Rust. Anchor makes it a bit simpler though, especially if the program you're invoking is also an Anchor program whose crate you can access.
 

--- a/content/anchor-pdas.md
+++ b/content/anchor-pdas.md
@@ -14,7 +14,7 @@ objectives:
 - The `realloc` constraint is used to reallocate space on an existing account
 - The `close` constraint is used to close an account and refund its rent
 
-# Overview
+# Lesson
 
 In this lesson you'll learn how to work with PDAs, reallocate accounts, and close accounts in Anchor.
 

--- a/content/arbitrary-cpi.md
+++ b/content/arbitrary-cpi.md
@@ -12,7 +12,7 @@ objectives:
 - Perform program checks in native programs by simply comparing the public key of the passed-in program to the progam you expected.
 - If a program is written in Anchor, then it may have a publicly available CPI module. This makes invoking the program from another Anchor program simple and secure. The Anchor CPI module automatically checks that the address of the program passed in matches the address of the program stored in the module.
 
-# Overview
+# Lesson
 
 A cross program invocation (CPI) is when one program invokes an instruction on another program. An “arbitrary CPI” is when a program is structured to issue a CPI to whatever program is passed into the instruction rather than expecting to perform a CPI to one specific program. Given that the callers of your program's instruction can pass any program they'd like into the instruction's list of accounts, failing to verify the address of a passed-in program results in your program performing CPIs to arbitrary programs.
 

--- a/content/bump-seed-canonicalization.md
+++ b/content/bump-seed-canonicalization.md
@@ -24,7 +24,7 @@ objectives:
     }
     ```
 
-# Overview
+# Lesson
 
 Bump seeds are a number between 0 and 255, inclusive, used to ensure that an address derived using [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html#method.create_program_address) is a valid PDA. The **canonical bump** is the highest bump value that produces a valid PDA. The standard in Solana is to *always use the canonical bump* when deriving PDAs, both for security and convenience. 
 

--- a/content/closing-accounts.md
+++ b/content/closing-accounts.md
@@ -18,7 +18,7 @@ objectives:
     pub receiver: SystemAccount<'info>
     ```
 
-# Overview
+# Lesson
 
 While it sounds simple, closing accounts properly can be tricky. There are a number of ways an attacker could circumvent having the account closed if you don't follow specific steps.
 

--- a/content/compressed-nfts.md
+++ b/content/compressed-nfts.md
@@ -14,7 +14,7 @@ objectives:
 - Supporting RPC providers **index** cNFT data off-chain when the cNFT is minted so that you can use the **Read API** to access the data
 - The **Metaplex Bubblegum program** is an abstraction on top of the **State Compression** program that enables you to more simply create, mint, and manage cNFT collections
 
-# Overview
+# Lesson
 
 Compressed NFTs (cNFTs) are exactly what their name suggests: NFTs whose structure takes up less account storage than traditional NFTs. Compressed NFTs leverage a concept called **State Compression** to store data in a way that drastically reduces costs.
 

--- a/content/cpi.md
+++ b/content/cpi.md
@@ -14,7 +14,7 @@ objectives:
 - CPIs make programs in the Solana ecosystem completely interoperable because all public instructions of a program can be invoked by another program via a CPI
 - Because we have no control over the accounts and data submitted to a program, it's important to verify all of the parameters passed into a CPI to ensure program security
 
-# Overview
+# Lesson
 
 ## What is a CPI?
 

--- a/content/deserialize-custom-data.md
+++ b/content/deserialize-custom-data.md
@@ -15,7 +15,7 @@ objectives:
 - You can get the accounts belonging to a program using `getProgramAccounts(programId)`.
 - Account data needs to be deserialized using the same layout used to store it in the first place. You can use `@coral-xyz/borsh` to create a schema.
 
-# Overview
+# Lesson
 
 In the last lesson, we serialized program data that was subsequently stored onchain by a Solana program. In this lesson, we’ll cover in greater detail how programs store data on the chain, how to retrieve data, and how to deserialize the data they store.
 ## Programs

--- a/content/deserialize-instruction-data.md
+++ b/content/deserialize-instruction-data.md
@@ -17,7 +17,7 @@ objectives:
 - You can use the `borsh` crate and the `derive` attribute to provide Borsh deserialization and serialization functionality to Rust structs
 - Rust `match` expressions help create conditional code paths based on the provided instruction
 
-# Overview
+# Lesson
 
 One of the most basic elements of a Solana program is the logic for handling instruction data. Most programs support multiple related functions and use differences in instruction data to determine which code path to execute. For example, two different data formats in the instruction data passed to the program may represent instructions for creating a new piece of data vs deleting the same piece of data.
 

--- a/content/duplicate-mutable-accounts.md
+++ b/content/duplicate-mutable-accounts.md
@@ -19,7 +19,7 @@ objectives:
 
 - In Anchor, you can use `constraint` to add an explicit constraint to an account checking that it is not the same as another account.
 
-# Overview
+# Lesson
 
 Duplicate Mutable Accounts refers to an instruction that requires two mutable accounts of the same type. When this occurs, you should validate that two accounts are different to prevent the same account from being passed into the instruction twice.
 

--- a/content/env-variables.md
+++ b/content/env-variables.md
@@ -14,7 +14,7 @@ objectives:
 -   Similarly, you can use the `cfg!` **macro** to compile different code paths based on the features that are enabled.
 -   Alternatively, you can achieve something similar to environment variables that can be modified after deployment by creating accounts and instructions that are only accessible by the program’s upgrade authority.
 
-# Overview
+# Lesson
 
 One of the difficulties engineers face across all types of software development is that of writing testable code and creating distinct environments for local development, testing, production, etc.
 

--- a/content/es/rust-macros.md
+++ b/content/es/rust-macros.md
@@ -15,7 +15,7 @@ objectives:
 -   An **Item** is a declaration that defines something that can be used in a Rust program, such as a struct, an enum, a trait, a function, or a method.
 -   A **TokenStream** is a sequence of tokens that represents a piece of source code, and can be passed to a procedural macro to allow it to access and manipulate the individual tokens in the code.
 
-# Overview
+# Lesson
 
 In Rust, a macro is a piece of code that you can write once and then "expand" to generate code at compile time. This can be useful when you need to generate code that is repetitive or complex, or when you want to use the same code in multiple places in your program.
 

--- a/content/fil/account-data-matching.md
+++ b/content/fil/account-data-matching.md
@@ -19,7 +19,7 @@ objectives:
     
 - Sa Anchor, maaari mong gamitin ang `constraint` upang suriin kung ang ibinigay na expression ay nagsusuri sa true. Bilang kahalili, maaari mong gamitin ang `may_isa` upang tingnan kung ang isang target na field ng account na nakaimbak sa account ay tumutugma sa susi ng isang account sa `Mga Account` na struct.
 
-# Overview
+# Lesson
 
 Ang pagtutugma ng data ng account ay tumutukoy sa mga pagsusuri sa pagpapatunay ng data na ginagamit upang i-verify na ang data na nakaimbak sa isang account ay tumutugma sa inaasahang halaga. Ang mga pagsusuri sa pagpapatunay ng data ay nagbibigay ng paraan upang magsama ng mga karagdagang paghihigpit upang matiyak na ang mga naaangkop na account ay naipapasa sa isang tagubilin.
 

--- a/content/fil/anchor-cpi.md
+++ b/content/fil/anchor-cpi.md
@@ -14,7 +14,7 @@ objectives:
 - Kung wala kang access sa mga function ng helper ng CPI, maaari mo pa ring gamitin ang `invoke` at `invoke_signed` nang direkta
 - Ginagamit ang **`error_code`** attribute macro para gumawa ng custom na Anchor Error
 
-# Overview
+# Lesson
 
 Kung iisipin mo ang [unang CPI lesson](cpi.md), maaalala mo na ang paggawa ng mga CPI ay maaaring maging mahirap gamit ang vanilla Rust. Ang Anchor ay ginagawa itong medyo mas simple, lalo na kung ang program na iyong ginagamit ay isa ring Anchor program na ang crate ay maaari mong ma-access.
 

--- a/content/fil/anchor-pdas.md
+++ b/content/fil/anchor-pdas.md
@@ -14,7 +14,7 @@ objectives:
 - Ang hadlang na `realloc` ay ginagamit upang muling maglaan ng espasyo sa isang umiiral nang account
 - Ginagamit ang `close` constraint upang isara ang isang account at i-refund ang renta nito
 
-# Overview
+# Lesson
 
 Sa araling ito, matututunan mo kung paano magtrabaho sa mga PDA, muling italaga ang mga account, at isara ang mga account sa Anchor.
 

--- a/content/fil/arbitrary-cpi.md
+++ b/content/fil/arbitrary-cpi.md
@@ -12,7 +12,7 @@ objectives:
 - Magsagawa ng mga pagsusuri ng programa sa mga katutubong programa sa pamamagitan lamang ng paghahambing ng pampublikong susi ng naipasa na programa sa programang iyong inaasahan.
 - Kung ang isang programa ay nakasulat sa Anchor, maaaring mayroon itong pampublikong CPI module. Ginagawa nitong simple at secure ang pag-invoke sa program mula sa isa pang Anchor program. Awtomatikong sinusuri ng Anchor CPI module na ang address ng program na ipinasa ay tumutugma sa address ng program na nakaimbak sa module.
 
-# Overview
+# Lesson
 
 Ang cross program invocation (CPI) ay kapag ang isang programa ay humihiling ng pagtuturo sa isa pang programa. Ang "arbitraryong CPI" ay kapag ang isang programa ay nakabalangkas na mag-isyu ng isang CPI sa anumang programa na ipinasa sa pagtuturo sa halip na umasa na magsagawa ng isang CPI sa isang partikular na programa. Dahil ang mga tumatawag sa pagtuturo ng iyong programa ay maaaring magpasa ng anumang program na gusto nila sa listahan ng mga account ng pagtuturo, ang hindi pag-verify sa address ng isang naipasa na programa ay nagreresulta sa iyong programa na gumaganap ng mga CPI sa mga arbitrary na programa.
 

--- a/content/fil/bump-seed-canonicalization.md
+++ b/content/fil/bump-seed-canonicalization.md
@@ -24,7 +24,7 @@ objectives:
     }
     ```
 
-# Overview
+# Lesson
 
 Ang bump seeds ay isang numero sa pagitan ng 0 at 255, kasama, na ginagamit upang matiyak na ang isang address ay nakuha gamit ang [`create_program_address`](https://docs.rs/solana-program/latest/solana_program/pubkey/struct.Pubkey.html# method.create_program_address) ay isang wastong PDA. Ang **canonical bump** ay ang pinakamataas na bump value na gumagawa ng valid PDA. Ang pamantayan sa Solana ay ang *palaging gamitin ang canonical bump* kapag kumukuha ng mga PDA, kapwa para sa seguridad at kaginhawahan.
 

--- a/content/fil/closing-accounts.md
+++ b/content/fil/closing-accounts.md
@@ -19,7 +19,7 @@ objectives:
     pub receiver: SystemAccount<'info>
     ```
 
-# Overview
+# Lesson
 
 Bagama't ito ay simple, ang pagsasara ng mga account nang maayos ay maaaring nakakalito. Mayroong ilang mga paraan na maaaring iwasan ng isang umaatake ang pagsasara ng account kung hindi mo susundin ang mga partikular na hakbang.
 

--- a/content/fil/compressed-nfts.md
+++ b/content/fil/compressed-nfts.md
@@ -14,7 +14,7 @@ objectives:
 - Pagsuporta sa mga provider ng RPC **index** cNFT data off-chain kapag ang cNFT ay minted para magamit mo ang **Read API** para ma-access ang data
 - Ang **Metaplex Bubblegum program** ay isang abstraction sa ibabaw ng **State Compression** program na nagbibigay-daan sa iyo upang mas simpleng lumikha, mag-mint, at pamahalaan ang mga koleksyon ng cNFT
 
-# Overview
+# Lesson
 
 Ang mga naka-compress na NFT (cNFTs) ay eksakto kung ano ang iminumungkahi ng kanilang pangalan: Mga NFT na ang istraktura ay tumatagal ng mas kaunting storage ng account kaysa sa mga tradisyonal na NFT. Ang mga naka-compress na NFT ay gumagamit ng isang konsepto na tinatawag na **State Compression** upang mag-imbak ng data sa paraang lubhang nakakabawas sa mga gastos.
 

--- a/content/fil/cpi.md
+++ b/content/fil/cpi.md
@@ -14,7 +14,7 @@ objectives:
 - Ginagawa ng mga CPI ang mga programa sa Solana ecosystem na ganap na interoperable dahil ang lahat ng pampublikong tagubilin ng isang programa ay maaaring gamitin ng isa pang programa sa pamamagitan ng isang CPI
 - Dahil wala kaming kontrol sa mga account at data na isinumite sa isang programa, mahalagang i-verify ang lahat ng mga parameter na ipinasa sa isang CPI upang matiyak ang seguridad ng programa
 
-# Overview
+# Lesson
 
 ## What is a CPI?
 

--- a/content/fil/deserialize-custom-data.md
+++ b/content/fil/deserialize-custom-data.md
@@ -15,7 +15,7 @@ objectives:
 - Makukuha mo ang mga account na kabilang sa isang program gamit ang `getProgramAccounts(programId)`.
 - Kailangang ma-deserialize ang data ng account gamit ang parehong layout na ginamit upang iimbak ito sa unang lugar. Maaari mong gamitin ang `@project-serum/borsh` para gumawa ng schema.
 
-# Overview
+# Lesson
 
 Sa huling aralin, na-serialize namin ang data ng programa na kasunod na inimbak on-chain ng isang Solana program. Sa araling ito, tatalakayin natin nang mas detalyado kung paano nag-iimbak ang mga program ng data sa chain, kung paano kunin ang data, at kung paano i-deserialize ang data na iniimbak nila.
 ## Programs

--- a/content/fil/deserialize-instruction-data.md
+++ b/content/fil/deserialize-instruction-data.md
@@ -17,7 +17,7 @@ objectives:
 - Maaari mong gamitin ang `borsh` crate at ang `derive` attribute para magbigay ng Borsh deserialization at serialization functionality sa Rust structs
 - Tumutulong ang mga expression na `match` na kalawang na lumikha ng mga conditional code path batay sa ibinigay na pagtuturo
 
-# Overview
+# Lesson
 
 Isa sa mga pinakapangunahing elemento ng isang programa ng Solana ay ang lohika para sa paghawak ng data ng pagtuturo. Karamihan sa mga program ay sumusuporta sa maraming nauugnay na function at gumagamit ng mga pagkakaiba sa data ng pagtuturo upang matukoy kung aling code path ang isasagawa. Halimbawa, ang dalawang magkaibang format ng data sa data ng pagtuturo na ipinasa sa program ay maaaring kumatawan sa mga tagubilin para sa paggawa ng bagong piraso ng data kumpara sa pagtanggal ng parehong piraso ng data.
 

--- a/content/fil/duplicate-mutable-accounts.md
+++ b/content/fil/duplicate-mutable-accounts.md
@@ -19,7 +19,7 @@ objectives:
 
 - Sa Anchor, maaari mong gamitin ang `constraint` upang magdagdag ng isang tahasang pagpilit sa isang account upang suriin na hindi ito katulad ng isa pang account.
 
-# Overview
+# Lesson
 
 Ang mga Duplicate na Mutable na Account ay tumutukoy sa isang tagubilin na nangangailangan ng dalawang nababagong account ng parehong uri. Kapag nangyari ito, dapat mong patunayan na ang dalawang account ay magkaiba upang maiwasan ang parehong account na maipasa sa pagtuturo nang dalawang beses.
 

--- a/content/fil/env-variables.md
+++ b/content/fil/env-variables.md
@@ -14,7 +14,7 @@ objectives:
 - Katulad nito, maaari mong gamitin ang `cfg!` **macro** upang mag-compile ng iba't ibang mga path ng code batay sa mga feature na pinagana.
 - Bilang kahalili, makakamit mo ang isang bagay na katulad ng mga variable ng kapaligiran na maaaring mabago pagkatapos ng pag-deploy sa pamamagitan ng paggawa ng mga account at tagubilin na maa-access lamang ng awtoridad sa pag-upgrade ng programa.
 
-# Overview
+# Lesson
 
 Ang isa sa mga paghihirap na kinakaharap ng mga inhinyero sa lahat ng uri ng software development ay ang pagsulat ng masusubok na code at paglikha ng mga natatanging kapaligiran para sa lokal na pag-unlad, pagsubok, produksyon, atbp.
 

--- a/content/fil/hello-world-program.md
+++ b/content/fil/hello-world-program.md
@@ -15,7 +15,7 @@ objectives:
 - Ang mga programang Solana ay may iisang **entry point** upang iproseso ang mga tagubilin
 - Pinoproseso ng isang program ang isang pagtuturo gamit ang **program_id**, listahan ng **accounts**, at **instruction_data** na kasama sa pagtuturo
 
-# Overview
+# Lesson
 
 Ang kakayahan ni Solana na magpatakbo ng arbitrary executable code ay bahagi ng kung bakit ito napakalakas. Ang mga programang Solana, na katulad ng "mga matalinong kontrata" sa iba pang mga kapaligiran ng blockchain, ay literal na backbone ng Solana ecosystem. At ang koleksyon ng mga programa ay lumalaki araw-araw habang ang mga developer at tagalikha ay nangangarap at naglalagay ng mga bagong programa.
 

--- a/content/fil/interact-with-wallets.md
+++ b/content/fil/interact-with-wallets.md
@@ -15,7 +15,7 @@ objectives:
 - Ang mga software wallet ay kadalasang **mga extension ng browser** na nagpapadali sa pagkonekta sa mga website
 - Pinapasimple ng **Wallet-Adapter library** ni Solana ang suporta ng mga extension ng browser ng wallet, na nagbibigay-daan sa iyong bumuo ng mga website na maaaring humiling ng address ng wallet ng user at magmungkahi ng mga transaksyon para lagdaan nila
 
-# Overview
+# Lesson
 
 ## Wallets
 

--- a/content/fil/intro-to-anchor-frontend.md
+++ b/content/fil/intro-to-anchor-frontend.md
@@ -17,7 +17,7 @@ objectives:
 - Isang bagay na **Anchor `Program`** ay nagbibigay ng custom na API upang makipag-ugnayan sa isang partikular na program. Lumilikha ka ng instance ng `Program` gamit ang IDL at `Provider` ng isang program.
 - Ang **Anchor `MethodsBuilder`** ay nagbibigay ng isang simpleng interface sa pamamagitan ng `Program` para sa mga tagubilin sa pagbuo at mga transaksyon
 
-# Overview
+# Lesson
 
 Pinapasimple ng Anchor ang proseso ng pakikipag-ugnayan sa mga program ng Solana mula sa kliyente sa pamamagitan ng pagbibigay ng file ng Interface Description Language (IDL) na sumasalamin sa istruktura ng isang programa. Ang paggamit ng IDL kasabay ng Anchor's Typescript library (`@coral-xyz/anchor`) ay nagbibigay ng pinasimpleng format para sa pagbuo ng mga tagubilin at transaksyon.
 

--- a/content/fil/intro-to-anchor.md
+++ b/content/fil/intro-to-anchor.md
@@ -12,7 +12,7 @@ objectives:
 - **Anchor macros** ay nagpapabilis sa proseso ng pagbuo ng mga programang Solana sa pamamagitan ng pag-abstract ng malaking halaga ng boilerplate code
 - Binibigyang-daan ka ng Anchor na bumuo ng **mga secure na programa** nang mas madali sa pamamagitan ng pagsasagawa ng ilang partikular na pagsusuri sa seguridad, nangangailangan ng pagpapatunay ng account, at pagbibigay ng simpleng paraan upang magpatupad ng mga karagdagang pagsusuri.
 
-# Overview
+# Lesson
 
 ## What is Anchor?
 

--- a/content/fil/intro-to-cryptography.md
+++ b/content/fil/intro-to-cryptography.md
@@ -14,7 +14,7 @@ objectives:
 - Ang **secret key** ay ginagamit upang i-verify ang awtoridad sa account. Gaya ng ipinahihiwatig ng pangalan, dapat mong palaging panatilihing *lihim* ang mga lihim na susi.
 - Ang `@solana/web3.js` ay nagbibigay ng mga function ng helper para sa paglikha ng bagong keypair, o para sa pagbuo ng keypair gamit ang isang umiiral nang secret key.
 
-# Overview
+# Lesson
 
 ## Symmetric and Asymmetric Cryptography
 

--- a/content/fil/intro-to-reading-data.md
+++ b/content/fil/intro-to-reading-data.md
@@ -12,7 +12,7 @@ objectives:
 - **Mga Account** ay nag-iimbak ng mga token, NFT, program, at data. Sa ngayon, tututuon tayo sa mga account na nag-iimbak ng SOL.
 - **Mga Address** ay tumuturo sa mga account sa network ng Solana. Maaaring basahin ng sinuman ang data sa isang ibinigay na address. Karamihan sa mga address ay **mga pampublikong key** din
 
-# Overview
+# Lesson
 
 ## Accounts
 

--- a/content/fil/intro-to-writing-data.md
+++ b/content/fil/intro-to-writing-data.md
@@ -12,7 +12,7 @@ objectives:
 
 Ang lahat ng pagbabago sa on-chain na data ay nangyayari sa pamamagitan ng **mga transaksyon**. Ang mga transaksyon ay kadalasang isang hanay ng mga tagubilin na humihimok ng mga programang Solana. Ang mga transaksyon ay atomic, ibig sabihin ay magtagumpay sila - kung ang lahat ng mga tagubilin ay naisakatuparan nang maayos - o nabigo, na parang hindi pa natakbo ang transaksyon.
 
-# Overview
+# Lesson
 
 ## Transactions
 

--- a/content/fil/local-setup.md
+++ b/content/fil/local-setup.md
@@ -15,7 +15,7 @@ objectives:
 - Kapag na-install mo na ang Rust at Solana CLI, magagawa mong buuin at i-deploy ang iyong mga programa nang lokal gamit ang mga command na `cargo build-bpf` at `solana program deploy`
 - Maaari mong tingnan ang mga log ng programa gamit ang command na `solana logs`
 
-# Overview
+# Lesson
 
 Sa ngayon sa kursong ito, ginamit namin ang Solana Playground upang bumuo at mag-deploy ng mga programang Solana. At habang ito ay isang mahusay na tool, para sa ilang mga kumplikadong proyekto ay maaaring mas gusto mong magkaroon ng isang lokal na kapaligiran sa pag-unlad na naka-set up. Maaaring ito ay upang magamit ang mga crates na hindi sinusuportahan ng Solana Playground, upang samantalahin ang mga custom na script o tooling na iyong ginawa, o dahil lang sa personal na kagustuhan.
 

--- a/content/fil/nfts-with-metaplex.md
+++ b/content/fil/nfts-with-metaplex.md
@@ -16,7 +16,7 @@ objectives:
 - Ang programang **Candy Machine** ay isang tool sa pamamahagi ng NFT na ginagamit upang lumikha at mag-mint ng mga NFT mula sa isang koleksyon
 - **Ang Sugar CLI** ay isang tool na nagpapasimple sa proseso ng pag-upload ng mga media/metadata file at paggawa ng Candy Machine para sa isang koleksyon
 
-# Overview
+# Lesson
 
 Ang Solana Non-Fungible Token (NFTs) ay mga SPL token na ginawa gamit ang Token program. Ang mga token na ito, gayunpaman, ay mayroon ding karagdagang metadata account na nauugnay sa bawat token mint. Nagbibigay-daan ito para sa isang malawak na iba't ibang mga kaso ng paggamit para sa mga token. Maaari mong epektibong i-tokenize ang anumang bagay, mula sa imbentaryo ng laro hanggang sa sining.
 

--- a/content/fil/oracles.md
+++ b/content/fil/oracles.md
@@ -15,7 +15,7 @@ objectives:
 - Maaari kang bumuo ng iyong sariling Oracle upang lumikha ng isang pasadyang feed ng data
 - Kailangan mong maging maingat sa pagpili ng iyong mga provider ng data feed
 
-# Overview
+# Lesson
 
 Ang Oracles ay mga serbisyong nagbibigay ng panlabas na data sa isang blockchain network. Ang mga blockchain ay likas na mga siled na kapaligiran na walang kaalaman sa labas ng mundo. Ang paghihigpit na ito ay likas na naglalagay ng limitasyon sa mga kaso ng paggamit para sa mga desentralisadong aplikasyon (dApps). Nagbibigay ang Oracles ng solusyon sa limitasyong ito sa pamamagitan ng paglikha ng isang desentralisadong paraan upang makakuha ng real-world na data na on-chain.
 

--- a/content/fil/owner-checks.md
+++ b/content/fil/owner-checks.md
@@ -21,7 +21,7 @@ if ctx.accounts.account.owner != ctx.program_id {
 - Ang mga uri ng account ng anchor program ay nagpapatupad ng katangiang `May-ari` na nagbibigay-daan sa wrapper ng `Account<'info, T>` na awtomatikong i-verify ang pagmamay-ari ng programa
 - Binibigyan ka ng Anchor ng opsyon na tahasang tukuyin ang may-ari ng isang account kung ito ay dapat na anuman maliban sa kasalukuyang nagsasagawa ng programa
 
-# Overview
+# Lesson
 
 Ang mga tseke ng may-ari ay ginagamit upang i-verify na ang isang account na ipinasa sa isang pagtuturo ay pagmamay-ari ng isang inaasahang programa. Pinipigilan nito ang mga account na pagmamay-ari ng isang hindi inaasahang programa na magamit sa isang pagtuturo.
 

--- a/content/fil/paging-ordering-filtering-data.md
+++ b/content/fil/paging-ordering-filtering-data.md
@@ -15,7 +15,7 @@ objectives:
 - Upang makatipid sa oras ng pagkalkula, maaari kang kumuha ng malaking bilang ng mga account nang wala ang kanilang data sa pamamagitan ng pag-filter sa mga ito upang magbalik lamang ng hanay ng mga pampublikong key
 - Kapag mayroon ka nang na-filter na listahan ng mga pampublikong key, maaari mong i-order ang mga ito at kunin ang data ng account na kinabibilangan nila
 
-# Overview
+# Lesson
 
 Maaaring napansin mo sa huling aralin na habang maaari kaming kumuha at magpakita ng listahan ng data ng account, wala kaming anumang butil na kontrol sa kung ilang account ang kukunin o ang kanilang order. Sa araling ito, malalaman natin ang tungkol sa ilang opsyon sa configuration para sa function na `getProgramAccounts` na magbibigay-daan sa mga bagay tulad ng paging, pag-order ng mga account, at pag-filter.
 

--- a/content/fil/pda-sharing.md
+++ b/content/fil/pda-sharing.md
@@ -12,7 +12,7 @@ objectives:
 - Pigilan ang parehong PDA na gamitin para sa maramihang mga account sa pamamagitan ng paggamit ng mga buto na user at/o domain-specific
 - Gamitin ang mga hadlang sa `seeds` at `bump` ng Anchor upang patunayan na ang isang PDA ay nakuha gamit ang inaasahang mga buto at bump
 
-# Overview
+# Lesson
 
 Ang pagbabahagi ng PDA ay tumutukoy sa paggamit ng parehong PDA bilang isang lumagda sa maraming user o domain. Lalo na kapag gumagamit ng mga PDA para sa pagpirma, maaaring mukhang angkop na gumamit ng isang pandaigdigang PDA upang kumatawan sa programa. Gayunpaman, nagbubukas ito ng posibilidad na pumasa ang pagpapatunay ng account ngunit naa-access ng isang user ang mga pondo, paglilipat, o data na hindi sa kanila.
 

--- a/content/fil/pda.md
+++ b/content/fil/pda.md
@@ -16,7 +16,7 @@ objectives:
 - Maaaring gamitin ang mga buto upang i-map ang data na nakaimbak sa isang hiwalay na PDA account
 - Maaaring lagdaan ng isang programa ang mga tagubilin sa ngalan ng mga PDA na nagmula sa ID nito
 
-# Overview
+# Lesson
 
 ## What is a Program Derived Address?
 

--- a/content/fil/program-architecture.md
+++ b/content/fil/program-architecture.md
@@ -13,7 +13,7 @@ objectives:
 - Gamitin ang Zero-Copy upang harapin ang mga account na masyadong malaki para sa `Box` (< 10MB)
 - Ang laki at ang pagkakasunud-sunod ng mga patlang sa isang bagay na account; ilagay ang mga patlang ng variable na haba sa dulo
 - Ang Solana ay maaaring magproseso nang magkatulad, ngunit maaari ka pa ring magkaroon ng mga bottleneck; alalahanin ang mga "nakabahaging" account na kailangang sulatan ng lahat ng user na nakikipag-ugnayan sa program
-# Overview
+# Lesson
 
 Ang Arkitektura ng Programa ang naghihiwalay sa hobbyist mula sa propesyonal. Ang paggawa ng mga gumaganang programa ay may higit na kinalaman sa system **design** kaysa sa code. At ikaw, bilang taga-disenyo, ay kailangang mag-isip tungkol sa:
 

--- a/content/fil/program-security.md
+++ b/content/fil/program-security.md
@@ -17,7 +17,7 @@ objectives:
 - **Pagpapatunay ng account** ay nangangailangan ng pagtiyak na ang mga ibinigay na account ay ang mga account na inaasahan mong magiging mga ito, hal. pagkuha ng mga PDA na may inaasahang mga binhi upang matiyak na ang address ay tumutugma sa ibinigay na account
 - Ang **Pagpapatunay ng data** ay nangangailangan ng pagtiyak na ang anumang ibinigay na data ay nakakatugon sa mga pamantayang kinakailangan ng programa
 
-# Overview
+# Lesson
 
 Sa huling dalawang aralin, pinagsikapan namin ang pagbuo ng programa sa Pagsusuri ng Pelikula. Ang resulta ay medyo cool! Nakakatuwang makakuha ng isang bagay na gumagana sa isang bagong kapaligiran sa pag-unlad.
 

--- a/content/fil/program-state-management.md
+++ b/content/fil/program-state-management.md
@@ -16,7 +16,7 @@ objectives:
 - Ang paggawa ng bagong account ay nangangailangan ng Cross Program Invocation (CPI) sa `create_account` na pagtuturo sa System Program
 - Ang pag-update sa field ng data sa isang account ay nangangailangan na i-serialize namin (i-convert sa byte array) ang data sa account
 
-# Overview
+# Lesson
 
 Ang Solana ay nagpapanatili ng bilis, kahusayan, at pagpapalawak sa bahagi sa pamamagitan ng paggawa ng mga programa na walang estado. Sa halip na magkaroon ng estado na naka-imbak sa mismong programa, ginagamit ng mga program ang modelo ng account ni Solana upang basahin ang estado mula at isulat ang estado upang paghiwalayin ang mga PDA account.
 

--- a/content/fil/reinitialization-attacks.md
+++ b/content/fil/reinitialization-attacks.md
@@ -17,7 +17,7 @@ objectives:
   ```
 - Upang gawing simple ito, gamitin ang hadlang na `init` ng Anchor upang lumikha ng isang account sa pamamagitan ng CPI sa program ng system at itakda ang discriminator nito
 
-# Overview
+# Lesson
 
 Ang pagsisimula ay tumutukoy sa pagtatakda ng data ng isang bagong account sa unang pagkakataon. Kapag nagpasimula ng isang bagong account, dapat kang magpatupad ng isang paraan upang suriin kung ang account ay nasimulan na. Kung walang naaangkop na pagsusuri, maaaring muling simulan ang isang umiiral na account at ma-overwrite ang umiiral nang data.
 

--- a/content/fil/rust-macros.md
+++ b/content/fil/rust-macros.md
@@ -15,7 +15,7 @@ objectives:
 - Ang **Item** ay isang deklarasyon na tumutukoy sa isang bagay na maaaring gamitin sa isang Rust program, gaya ng isang struct, isang enum, isang katangian, isang function, o isang paraan.
 - Ang **TokenStream** ay isang sequence ng mga token na kumakatawan sa isang piraso ng source code, at maaaring ipasa sa isang procedural macro upang payagan itong ma-access at manipulahin ang mga indibidwal na token sa code.
 
-# Overview
+# Lesson
 
 Sa Rust, ang macro ay isang piraso ng code na maaari mong isulat nang isang beses at pagkatapos ay "palawakin" upang makabuo ng code sa oras ng pag-compile. Maaari itong maging kapaki-pakinabang kapag kailangan mong bumuo ng code na paulit-ulit o kumplikado, o kapag gusto mong gamitin ang parehong code sa maraming lugar sa iyong programa.
 

--- a/content/fil/serialize-instruction-data.md
+++ b/content/fil/serialize-instruction-data.md
@@ -16,7 +16,7 @@ objectives:
 - Upang maipasa ang data ng pagtuturo mula sa isang kliyente, dapat itong i-serialize sa isang byte buffer. Upang mapadali ang prosesong ito ng serialization, gagamitin namin ang [Borsh](https://borsh.io/).
 - Maaaring mabigo ang mga transaksyon na maproseso ng blockchain para sa anumang bilang ng mga kadahilanan, tatalakayin natin ang ilan sa mga pinakakaraniwan dito.
 
-# Overview
+# Lesson
 
 ## Transactions
 

--- a/content/fil/signer-auth.md
+++ b/content/fil/signer-auth.md
@@ -21,7 +21,7 @@ objectives:
 - Sa Anchor, maaari mong gamitin ang **`Signer`** na uri ng account sa struct ng pagpapatunay ng iyong account upang awtomatikong magsagawa ang Anchor ng signer check sa isang partikular na account
 - Ang Anchor ay mayroon ding hadlang sa account na awtomatikong magbe-verify na ang isang partikular na account ay pumirma ng isang transaksyon
 
-# Overview
+# Lesson
 
 Ginagamit ang mga tseke ng signer para i-verify na pinahintulutan ng may-ari ng isang account ang isang transaksyon. Kung walang tseke ng signer, ang mga pagpapatakbo na ang pagpapatupad ay dapat na limitado sa mga partikular na account lamang ang posibleng gawin ng anumang account. Sa pinakamasamang sitwasyon, maaari itong magresulta sa mga wallet na ganap na maubos ng mga umaatake na pumasa sa anumang account na gusto nila sa isang pagtuturo.
 

--- a/content/fil/solana-pay.md
+++ b/content/fil/solana-pay.md
@@ -12,7 +12,7 @@ objectives:
 - **Partial signing** ng mga transaksyon ay nagbibigay-daan para sa paglikha ng mga transaksyon na nangangailangan ng maramihang mga lagda bago sila isumite sa network
 - Ang **Transaction gating** ay nagsasangkot ng pagpapatupad ng mga panuntunan na tumutukoy kung ang ilang partikular na transaksyon ay pinapayagang iproseso o hindi, batay sa ilang kundisyon o pagkakaroon ng partikular na data sa transaksyon
 
-# Overview
+# Lesson
 
 Ang komunidad ng Solana ay patuloy na pinapabuti at pinapalawak ang paggana ng network. Ngunit hindi iyon palaging nangangahulugan ng pagbuo ng bagong teknolohiya. Minsan ito ay nangangahulugan ng paggamit ng mga umiiral na tampok ng network sa bago at kawili-wiling mga paraan.
 

--- a/content/fil/token-program.md
+++ b/content/fil/token-program.md
@@ -16,7 +16,7 @@ objectives:
 - **Token Accounts** ay ginagamit upang maghawak ng mga Token ng isang partikular na Token Mint
 - Ang paggawa ng Mga Token Mint at Token Account ay nangangailangan ng paglalaan ng **renta** sa SOL. Ang renta para sa isang Token Account ay maaaring i-refund kapag ang account ay sarado, gayunpaman, ang Token Mint ay kasalukuyang hindi maaaring isara
 
-# Overview
+# Lesson
 
 Ang Token Program ay isa sa maraming programa na ginawang available ng Solana Program Library (SPL). Naglalaman ito ng mga tagubilin para sa paglikha at pakikipag-ugnayan sa SPL-Tokens. Ang mga token na ito ay kumakatawan sa lahat ng hindi katutubong (i.e. hindi SOL) na mga token sa network ng Solana.
 

--- a/content/fil/token-swap.md
+++ b/content/fil/token-swap.md
@@ -14,7 +14,7 @@ objectives:
 - Nagagawa ng mga developer na lumikha at gumamit ng **mga liquidity pool** upang magpalit sa pagitan ng anumang SPL token na gusto nila.
 - Gumagamit ang program ng mathematical formula na tinatawag na "**curve**" para kalkulahin ang presyo ng lahat ng trade. Nilalayon ng mga curves na gayahin ang normal na dynamics ng market: halimbawa, habang bumibili ang mga trader ng maraming isang uri ng token, tumataas ang halaga ng ibang uri ng token.
 
-# Overview
+# Lesson
 
 ## Swap Pools
 

--- a/content/fil/type-cosplay.md
+++ b/content/fil/type-cosplay.md
@@ -37,7 +37,7 @@ objectives:
 - Sa Anchor, awtomatikong ipinapatupad ng mga uri ng program account ang katangiang `Discriminator` na lumilikha ng 8 byte na natatanging identifier para sa isang uri
 - Gamitin ang uri ng `Account<'info, T>` ng Anchor upang awtomatikong suriin ang discriminator ng account kapag deserialize ang data ng account
 
-# Overview
+# Lesson
 
 Ang "Type cosplay" ay tumutukoy sa isang hindi inaasahang uri ng account na ginagamit sa halip na isang inaasahang uri ng account. Sa ilalim ng hood, ang data ng account ay iniimbak lamang bilang isang hanay ng mga byte na na-deserialize ng isang programa sa isang custom na uri ng account. Nang hindi nagpapatupad ng paraan upang tahasang makilala ang mga uri ng account, ang data ng account mula sa hindi inaasahang account ay maaaring magresulta sa paggamit ng pagtuturo sa mga hindi sinasadyang paraan.
 

--- a/content/fil/versioned-transaction.md
+++ b/content/fil/versioned-transaction.md
@@ -12,7 +12,7 @@ objectives:
 - **Mga Bersyon na Transaksyon** ay tumutukoy sa isang paraan upang suportahan ang parehong mga legacy na bersyon at mas bagong bersyon ng mga format ng transaksyon. Ang orihinal na format ng transaksyon ay "legacy" at ang mga bagong bersyon ng transaksyon ay nagsisimula sa bersyon 0. Ipinatupad ang mga bersyong transaksyon upang suportahan ang paggamit ng Address Lookup Tables (tinatawag ding lookup table o LUTs).
 - **Mga Talaan ng Paghahanap ng Address** ay mga account na ginagamit upang mag-imbak ng mga address ng iba pang mga account, na maaaring i-reference sa mga may bersyong transaksyon gamit ang isang 1 byte na index sa halip na ang buong 32 byte bawat address. Ito ay nagbibigay-daan sa paglikha ng mas kumplikadong mga transaksyon kaysa sa kung ano ang posible bago ang pagpapakilala ng mga LUT.
 
-# Overview
+# Lesson
 
 Sa disenyo, ang mga transaksyon sa Solana ay limitado sa 1232 bytes. Mabibigo ang mga transaksyong lalampas sa laki na ito. Bagama't pinapagana nito ang isang bilang ng mga pag-optimize ng network, maaari din nitong limitahan ang mga uri ng mga pagpapatakbong atomic na maaaring gawin sa network.
 

--- a/content/fil/vrf.md
+++ b/content/fil/vrf.md
@@ -13,7 +13,7 @@ objectives:
 - Ang VRF ay isang public-key pseudorandom function na nagbibigay ng mga patunay na ang mga output nito ay nakalkula nang tama.
 - Nag-aalok ang Switchboard ng developer-friendly na VRF para sa Solana ecosystem.
 
-# Overview
+# Lesson
 
 ## Randomness On-Chain
 

--- a/content/generalized-state-compression.md
+++ b/content/generalized-state-compression.md
@@ -13,7 +13,7 @@ objectives:
 - Concurrent merkle trees are a specialized version of merkle trees that allow concurrent updates.
 - Because data in a state-compressed program is not stored on-chain, you have to user indexers to keep an off-chain cache of the data and then verify that data against the onchain merkle tree.
 
-# Overview
+# Lesson
 
 Previously, we discussed state compression in the context of compressed NFTs. At the time of writing, compressed NFTs represent the most common use case for state compression, but it’s possible to use state compression within any program. In this lesson, we’ll discuss state compression in more generalized terms so that you can apply it to any of your programs.
 

--- a/content/hello-world-program.md
+++ b/content/hello-world-program.md
@@ -15,7 +15,7 @@ objectives:
 - Solana programs have a single **entry point** to process instructions
 - A program processes an instruction using the **program_id**, list of **accounts**, and **instruction_data** included with the instruction
 
-# Overview
+# Lesson
 
 Solana's ability to run arbitrary executable code is part of what makes it so powerful. Solana programs, similar to "smart contracts" in other blockchain environments, are quite literally the backbone of the Solana ecosystem. And the collection of programs grows daily as developers and creators dream up and deploy new programs.
 

--- a/content/interact-with-wallets.md
+++ b/content/interact-with-wallets.md
@@ -15,7 +15,7 @@ objectives:
 - Software wallets are often **browser extensions** that facilitate connecting to websites
 - Solana’s **Wallet-Adapter library** simplifies the support of wallet browser extensions, allowing you to build websites that can request a user’s wallet address and propose transactions for them to sign
 
-# Overview
+# Lesson
 
 ## Wallets
 

--- a/content/intro-to-anchor-frontend.md
+++ b/content/intro-to-anchor-frontend.md
@@ -17,7 +17,7 @@ objectives:
 - An **Anchor `Program`** object provides a custom API to interact with a specific program. You create a `Program` instance using a program's IDL and `Provider`.
 - The **Anchor `MethodsBuilder`** provides a simple interface through `Program` for building instructions and transactions
 
-# Overview
+# Lesson
 
 Anchor simplifies the process of interacting with Solana programs from the client by providing an Interface Description Language (IDL) file that reflects the structure of a program. Using the IDL in conjunction with Anchor's Typescript library (`@coral-xyz/anchor`) provides a simplified format for building instructions and transactions.
 

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -12,7 +12,7 @@ objectives:
 - **Anchor macros** speed up the process of building Solana programs by abstracting away a significant amount of boilerplate code
 - Anchor allows you to build **secure programs** more easily by performing certain security checks, requiring account validation, and providing a simple way to implement additional checks.
 
-# Overview
+# Lesson
 
 ## What is Anchor?
 

--- a/content/intro-to-cryptography.md
+++ b/content/intro-to-cryptography.md
@@ -14,7 +14,7 @@ objectives:
 - The **secret key** is used to verify authority over the account. As the name suggests, you should always keep secret keys *secret*.
 - `@solana/web3.js` provides helper functions for creating a brand new keypair, or for constructing a keypair using an existing secret key. 
 
-# Overview
+# Lesson
 
 ## Symmetric and Asymmetric Cryptography
 

--- a/content/intro-to-custom-on-chain-programs.md
+++ b/content/intro-to-custom-on-chain-programs.md
@@ -8,7 +8,7 @@ objectives:
 
 Solana has multiple onchain programs you can use. Instructions that use these programs need to have data in a custom format determined by the program.
 
-# Overview
+# Lesson
 ### Instructions
 
 In previous chapters, we used the `SystemProgram.transfer()` function to create an instruction to send SOL.

--- a/content/intro-to-reading-data.md
+++ b/content/intro-to-reading-data.md
@@ -12,7 +12,7 @@ objectives:
 - **Accounts** store tokens, NFTs, programs, and data. For now we’ll focus on accounts that store SOL. 
 - **Addresses** point to accounts on the Solana network. Anyone can read the data in a given address. Most addresses are also **public keys**.
 
-# Overview
+# Lesson
 
 ### Accounts
 

--- a/content/intro-to-solana-mobile.md
+++ b/content/intro-to-solana-mobile.md
@@ -14,7 +14,7 @@ objectives:
 - The simplest way to get started creating Solana mobile applications is with Solana Mobile's [React Native packages](https://docs.solanamobile.com/react-native/setup) `@solana-mobile/mobile-wallet-adapter-protocol` and `@solana-mobile/mobile-wallet-adapter-protocol-web3js`
 - React Native is very similar to React with a few mobile quirks
 
-# Overview
+# Lesson
 
 Solana Mobile Stack (SMS) is designed to help developers create mobile dApps with a seamless UX. It consists of the [Mobile Wallet Adapter (MWA)](https://docs.solanamobile.com/getting-started/overview#mobile-wallet-adapter), [Seed Vault](https://docs.solanamobile.com/getting-started/overview#seed-vault), and the [Solana dApp Store](https://docs.solanamobile.com/getting-started/overview#solana-dapp-store).
 

--- a/content/intro-to-writing-data.md
+++ b/content/intro-to-writing-data.md
@@ -12,7 +12,7 @@ objectives:
 
 All modifications to onchain data happen through **transactions**. Transactions are mostly a set of instructions that invoke Solana programs. Transactions are atomic, meaning they either succeed - if all the instructions have executed properly - or fail, as if the transaction hasn't been run at all. 
 
-# Overview
+# Lesson
 
 ## Transactions are atomic
 

--- a/content/local-setup.md
+++ b/content/local-setup.md
@@ -15,7 +15,7 @@ objectives:
 - Once you have Rust and Solana CLI installed, you’ll be able to build and deploy your programs locally using the `cargo build-bpf` and `solana program deploy` commands
 - You can view program logs using the `solana logs` command
 
-# Overview
+# Lesson
 
 So far in this course, we've used Solana Playground to develop and deploy Solana programs. And while it's a great tool, for certain complex projects you may prefer to have a local development environment set up. This may be in order to use crates not supported by Solana Playground, to take advantage of custom scripts or tooling you've created, or simply out of personal preference.
 

--- a/content/mwa-deep-dive.md
+++ b/content/mwa-deep-dive.md
@@ -13,7 +13,7 @@ objectives:
 - MWA handles all of its wallet interaction within the `transact` function
 - Solana Mobile's `walletlib` does the heavy lifting for surfacing wallet requests to wallet apps
 
-# Overview
+# Lesson
 
 Wallets exist to protect your secret keys. While some applications might have app-specific keys, many crypto use cases rely on a single identity used across multiple apps. In these cases, you very much want to be careful about how you expose signing across these apps. You don't want to share your secret key with all of them, which means you need a standard for allowing apps to submit transactions for signature to a secure wallet app that holds your secret key. This is where the Mobile Wallet Adapter (MWA) comes in. It's the transport layer to connect your mobile dApps to your wallet.
 

--- a/content/nfts-with-metaplex.md
+++ b/content/nfts-with-metaplex.md
@@ -16,7 +16,7 @@ objectives:
 - The **Candy Machine** program is an NFT distribution tool used to create and mint NFTs from a collection
 - **Sugar CLI** is a tool that simplifies the process of uploading media/metadata files and creating a Candy Machine for a collection
 
-# Overview
+# Lesson
 
 Solana Non-Fungible Tokens (NFTs) are SPL tokens created using the Token program. These tokens, however, also have an additional metadata account associated with each token mint. This allows for a wide variety of use cases for tokens. You can effectively tokenize anything, from game inventory to art.
 

--- a/content/oracles.md
+++ b/content/oracles.md
@@ -15,7 +15,7 @@ objectives:
 - You can build your own Oracle to create a custom data feed
 - You have to be careful when choosing your data feed providers
 
-# Overview
+# Lesson
 
 Oracles are services that provide external data to a blockchain network. Blockchains by nature are siloed environments that have no knowledge of the outside world. This constraint inherently puts a limit on the use cases for decentralized applications (dApps). Oracles provide a solution to this limitation by creating a decentralized way to get real-world data on-chain.
 

--- a/content/owner-checks.md
+++ b/content/owner-checks.md
@@ -21,7 +21,7 @@ if ctx.accounts.account.owner != ctx.program_id {
 - Anchor program account types implement the `Owner` trait which allows the `Account<'info, T>` wrapper to automatically verify program ownership
 - Anchor gives you the option to explicitly define the owner of an account if it should be anything other than the currently executing program
 
-# Overview
+# Lesson
 
 Owner checks are used to verify that an account passed into an instruction is owned by an expected program. This prevents accounts owned by an unexpected program from being used in an instruction.
 

--- a/content/paging-ordering-filtering-data.md
+++ b/content/paging-ordering-filtering-data.md
@@ -15,7 +15,7 @@ objectives:
 - To save on compute time, you can fetch a large number of accounts without their data by filtering them to return just an array of public keys
 - Once you have a filtered list of public keys, you can order them and fetch the account data they belong to
 
-# Overview
+# Lesson
 
 You may have noticed in the last lesson that while we could fetch and display a list of account data, we didn’t have any granular control over how many accounts to fetch or their order. In this lesson, we’ll learn about some configuration options for the `getProgramAccounts` function that will enable things like paging, ordering accounts, and filtering.
 

--- a/content/pda-sharing.md
+++ b/content/pda-sharing.md
@@ -12,7 +12,7 @@ objectives:
 - Prevent the same PDA from being used for multiple accounts by using seeds that are user and/or domain-specific
 - Use Anchor’s `seeds` and `bump` constraints to validate that a PDA is derived using the expected seeds and bump
 
-# Overview
+# Lesson
 
 PDA sharing refers to using the same PDA as a signer across multiple users or domains. Especially when using PDAs for signing, it may seem appropriate to use a global PDA to represent the program. However, this opens up the possibility of account validation passing but a user being able to access funds, transfers, or data not belonging to them.
 

--- a/content/pda.md
+++ b/content/pda.md
@@ -16,7 +16,7 @@ objectives:
 - Seeds can be used to map to the data stored in a separate PDA account
 - A program can sign instructions on behalf of the PDAs derived from its ID
 
-# Overview
+# Lesson
 
 ## What is a Program Derived Address?
 

--- a/content/program-architecture.md
+++ b/content/program-architecture.md
@@ -14,7 +14,7 @@ objectives:
 - The size and the order of fields in an account matter; put variable length fields at the end
 - Solana can process in parallel, but you can still run into bottlenecks; be mindful of "shared" accounts that all users interacting with the program have to write to
 
-# Overview
+# Lesson
 
 Program Architecture is what separates the hobbyist from the professional. Crafting performant programs has more to do with system **design** than it does with the code. And you, as the designer, need to think about: 
 

--- a/content/program-security.md
+++ b/content/program-security.md
@@ -17,7 +17,7 @@ objectives:
 - **Account validation** entails ensuring that provided accounts are the accounts you expect them to be, e.g. deriving PDAs with the expected seeds to make sure the address matches the provided account
 - **Data validation** entails ensuring that any provided data meets the criteria required by the program
 
-# Overview
+# Lesson
 
 In the last two lessons we worked through building a Movie Review program together. The end result is pretty cool! It's exciting to get something working in a new development environment.
 

--- a/content/program-state-management.md
+++ b/content/program-state-management.md
@@ -16,7 +16,7 @@ objectives:
 - Creating a new account requires a Cross Program Invocation (CPI) to the `create_account` instruction on the System Program
 - Updating the data field on an account requires that we serialize (convert to byte array) the data into the account
 
-# Overview
+# Lesson
 
 Solana maintains speed, efficiency, and extensibility in part by making programs stateless. Rather than having state stored on the program itself, programs use Solana's account model to read state from and write state to separate PDA accounts.
 

--- a/content/reinitialization-attacks.md
+++ b/content/reinitialization-attacks.md
@@ -17,7 +17,7 @@ objectives:
   ```
 - To simplify this, use Anchor’s `init` constraint to create an account via a CPI to the system program and sets its discriminator
 
-# Overview
+# Lesson
 
 Initialization refers to setting the data of a new account for the first time. When initializing a new account, you should implement a way to check if the account has already been initialized. Without an appropriate check, an existing account could be reinitialized and have existing data overwritten.
 

--- a/content/rust-macros.md
+++ b/content/rust-macros.md
@@ -15,7 +15,7 @@ objectives:
 -   An **Item** is a declaration that defines something that can be used in a Rust program, such as a struct, an enum, a trait, a function, or a method.
 -   A **TokenStream** is a sequence of tokens that represents a piece of source code, and can be passed to a procedural macro to allow it to access and manipulate the individual tokens in the code.
 
-# Overview
+# Lesson
 
 In Rust, a macro is a piece of code that you can write once and then "expand" to generate code at compile time. This can be useful when you need to generate code that is repetitive or complex, or when you want to use the same code in multiple places in your program.
 

--- a/content/serialize-instruction-data.md
+++ b/content/serialize-instruction-data.md
@@ -16,7 +16,7 @@ objectives:
 - In order to pass instruction data from a client, it must be serialized into a byte buffer. To facilitate this process of serialization, we will be using [Borsh](https://borsh.io/).
 - Transactions can fail to be processed by the blockchain for any number of reasons, we’ll discuss some of the most common ones here.
 
-# Overview
+# Lesson
 
 ## Transactions
 

--- a/content/signer-auth.md
+++ b/content/signer-auth.md
@@ -21,7 +21,7 @@ objectives:
 - In Anchor, you can use the **`Signer`** account type in your account validation struct to have Anchor automatically perform a signer check on a given account
 - Anchor also has an account constraint that will automatically verify that a given account has signed a transaction
 
-# Overview
+# Lesson
 
 Signer checks are used to verify that a given account’s owner has authorized a transaction. Without a signer check, operations whose execution should be limited to only specific accounts can potentially be performed by any account. In the worst case scenario, this could result in wallets being completely drained by attackers passing in whatever account they want to an instruction.
 

--- a/content/solana-mobile-dApps-with-expo.md
+++ b/content/solana-mobile-dApps-with-expo.md
@@ -12,7 +12,7 @@ objectives:
 - In addition to simplifying the build/deploy process, Expo provides packages that give you access to mobile devices' peripherals and capabilities
 - A lot of Solana ecosystem libraries don't support React native out of the box, but you can typically use them with the right [polyfills](https://developer.mozilla.org/en-US/docs/Glossary/Polyfill)
 
-# Overview
+# Lesson
 
 So far in exploring Solana Mobile, we've used vanilla React Native to build very simple mobile dApps. Just like many web developers opt to use frameworks built on top of React, like Next.js, many React Native developers opt to use frameworks and tooling that simplify the React Native development, testing, and deployment process. The most common of these is [React Native Expo](https://docs.expo.dev/tutorial/introduction/).
 

--- a/content/solana-pay.md
+++ b/content/solana-pay.md
@@ -12,7 +12,7 @@ objectives:
 -   **Partial signing** of transactions allows for the creation of transactions that require multiple signatures before they are submitted to the network
 -   **Transaction gating** involves implementing rules that determine whether certain transactions are allowed to be processed or not, based on certain conditions or the presence of specific data in the transaction
 
-# Overview
+# Lesson
 
 The Solana community is continually improving and expanding the network's functionality. But that doesn't always mean developing brand new technology. Sometimes it means leveraging the network's existing features in new and interesting ways.
 

--- a/content/token-program.md
+++ b/content/token-program.md
@@ -16,7 +16,7 @@ objectives:
 - **Token Accounts** are used to hold Tokens of a specific Token Mint
 - Creating Token Mints and Token Accounts requires allocating **rent** in SOL. The rent for a Token Account can be refunded when the account is closed, however, Token Mints currently cannot be closed
 
-# Overview
+# Lesson
 
 The Token Program is one of many programs made available by the Solana Program Library (SPL). It contains instructions for creating and interacting with SPL-Tokens. These tokens represent all non-native (i.e. not SOL) tokens on the Solana network.
 

--- a/content/type-cosplay.md
+++ b/content/type-cosplay.md
@@ -37,7 +37,7 @@ objectives:
 - In Anchor, program account types automatically implement the `Discriminator` trait which creates an 8 byte unique identifier for a type
 - Use Anchor’s `Account<'info, T>` type to automatically check the discriminator of the account when deserializing the account data
 
-# Overview
+# Lesson
 
 “Type cosplay” refers to an unexpected account type being used in place of an expected account type. Under the hood, account data is simply stored as an array of bytes that a program deserializes into a custom account type. Without implementing a way to explicitly distinguish between account types, account data from an unexpected account could result in an instruction being used in unintended ways.
 

--- a/content/versioned-transaction.md
+++ b/content/versioned-transaction.md
@@ -12,7 +12,7 @@ objectives:
 -   **Versioned Transactions** refers to a way to support both legacy versions and newer versions of transaction formats. The original transaction format is "legacy" and new transaction versions start at version 0. Versioned transactions were implemented in order to support the use of Address Lookup Tables (also called lookup tables or LUTs).
 -   **Address Lookup Tables** are accounts used to store addresses of other accounts, which can then be referenced in versioned transactions using a 1 byte index instead of the full 32 bytes per address. This enables the creation of more complex transactions than what was possible prior to the introduction of LUTs.
 
-# Overview
+# Lesson
 
 By design, Solana transactions are limited to 1232 bytes. Transactions exceeding this size will fail. While this enables a number of network optimizations, it can also limit the types of atomic operations that can be performed on the network.
 

--- a/content/vrf.md
+++ b/content/vrf.md
@@ -13,7 +13,7 @@ objectives:
 - A VRF is a public-key pseudorandom function that provides proofs that its outputs were calculated correctly.
 - Switchboard offers a developer-friendly VRF for the Solana ecosystem.
 
-# Overview
+# Lesson
 
 ## Randomness On-Chain
 

--- a/extract-objectives.ts
+++ b/extract-objectives.ts
@@ -44,13 +44,13 @@ await Promise.all(
     let link = `https://www.soldev.app/course/${file.split(".")[0]}`;
     let objectives = thingsWeCareAbout.objectives.join(", ");
 
-    // cut the thingsWeCareAbout.content string for only items between '# Summary' and '# Overview'
+    // cut the thingsWeCareAbout.content string for only items between '# Summary' and '# Lesson'
     let summaryParagraph = "";
 
     try {
       summaryParagraph = thingsWeCareAbout.content
         .split("# Summary")[1]
-        .split("# Overview")[0]
+        .split("# Lesson")[0]
         .replace(/\n/g, " ");
     } catch (error) {
       log(`Error: bad formatting in ${file}`);


### PR DESCRIPTION
This means the explanatory part of the lesson is just called 'lesson'. 

@jamesrp13 what do you think? We discussed this a little while ago and didn't come to a conclusion. It's not perfect (the word 'lesson' is now overloaded) but also 'Overview' seemed like a Summary. Happy to throw this away if we can think of a better name though.
