### PR TITLE
Fixed typos and minor code issues in the Anchor module

### DIFF
--- a/content/anchor-cpi.md
+++ b/content/anchor-cpi.md
@@ -392,10 +392,14 @@ Next, let’s update the `add_movie_review` instruction to do the following:
 
 Fortunately, we can use the `anchor_spl` crate to access helper functions and types like `mint_to` and `MintTo` for constructing our CPI to the Token Program. `mint_to` takes a `CpiContext` and integer as arguments, where the integer represents the number of tokens to mint. `MintTo` can be used for the list of accounts that the mint instruction needs.
 
+Update your `use` statements to include:
+
 ```rust
 use anchor_spl::token::{mint_to, MintTo, Mint, TokenAccount, Token};
 use anchor_spl::associated_token::AssociatedToken;
 ```
+
+Next, update the `add_movie_review` function to:
 
 ```rust
 pub fn add_movie_review(ctx: Context<AddMovieReview>, title: String, description: String, rating: u8) -> Result<()> {
@@ -422,7 +426,7 @@ pub fn add_movie_review(ctx: Context<AddMovieReview>, title: String, description
             },
             &[&[
                 "mint".as_bytes(),
-                &[*ctx.bumps.get("mint").unwrap()] // &[ctx.bumps.mint] for Anchor >=0.29
+                &[ctx.bumps.mint]
             ]]
         ),
         10*10^6

--- a/content/anchor-pdas.md
+++ b/content/anchor-pdas.md
@@ -361,7 +361,7 @@ Within the instruction logic, we’ll populate the data of the new `movie_review
 
 ```rust
 #[program]
-pub mod movie_review{
+pub mod anchor_movie_review_program{
     use super::*;
 
     pub fn add_movie_review(
@@ -528,7 +528,7 @@ pub struct DeleteMovieReview<'info> {
 }
 ```
 
-Here we use the `close` constraint to specify we are closing the `movie_review` account and that the rent should be refunded to the `initializer` account. We also include the `seeds` and `bump` constraints for the the `movie_review` account for validation. Anchor then handles the additional logic required to securely close the account.
+Here we use the `close` constraint to specify we are closing the `movie_review` account and that the rent should be refunded to the `initializer` account. We also include the `seeds` and `bump` constraints for the `movie_review` account for validation. Anchor then handles the additional logic required to securely close the account.
 
 ### 6. Testing
 
@@ -543,7 +543,7 @@ Here we:
 ```typescript
 import * as anchor from "@coral-xyz/anchor"
 import { Program } from "@coral-xyz/anchor"
-import { assert, expect } from "chai"
+import { expect } from "chai"
 import { AnchorMovieReviewProgram } from "../target/types/anchor_movie_review_program"
 
 describe("anchor-movie-review-program", () => {
@@ -575,6 +575,8 @@ describe("anchor-movie-review-program", () => {
 
 Next, let's create the first test for the `addMovieReview` instruction. Note that we don't explicitly add `.accounts`. This is because the `Wallet` from `AnchorProvider` is automatically included as a signer, Anchor can infer certain accounts like `SystemProgram`, and Anchor can also infer the `movieReview` PDA from the `title` instruction argument and the signer's public key.
 
+Note: don't forget to turn on seed inference with `seeds = true` in the `Anchor.toml`.
+
 Once the instruction runs, we then fetch the `movieReview` account and check that the data stored on the account match the expected values.
 
 ```typescript
@@ -585,10 +587,10 @@ it("Movie review is added`", async () => {
     .rpc()
 
   const account = await program.account.movieAccountState.fetch(moviePda)
-  expect(movie.title === account.title)
-  expect(movie.rating === account.rating)
-  expect(movie.description === account.description)
-  expect(account.reviewer === provider.wallet.publicKey)
+  expect(account.title).to.equal(movie.title)
+  expect(account.rating).to.equal(movie.rating)
+  expect(account.description).to.equal(movie.description)
+  expect(account.reviewer.toBase58()).to.equal(provider.wallet.publicKey.toBase58())
 })
 ```
 
@@ -604,10 +606,10 @@ it("Movie review is updated`", async () => {
     .rpc()
 
   const account = await program.account.movieAccountState.fetch(moviePda)
-  expect(movie.title === account.title)
-  expect(newRating === account.rating)
-  expect(newDescription === account.description)
-  expect(account.reviewer === provider.wallet.publicKey)
+  expect(account.title).to.equal(movie.title)
+  expect(account.rating).to.equal(newRating)
+  expect(account.description).to.equal(newDescription)
+  expect(account.reviewer.toBase58()).to.equal(provider.wallet.publicKey.toBase58())
 })
 ```
 

--- a/content/anchor-pdas.md
+++ b/content/anchor-pdas.md
@@ -575,7 +575,7 @@ describe("anchor-movie-review-program", () => {
 
 Next, let's create the first test for the `addMovieReview` instruction. Note that we don't explicitly add `.accounts`. This is because the `Wallet` from `AnchorProvider` is automatically included as a signer, Anchor can infer certain accounts like `SystemProgram`, and Anchor can also infer the `movieReview` PDA from the `title` instruction argument and the signer's public key.
 
-Note: don't forget to turn on seed inference with `seeds = true` in the `Anchor.toml`.
+Note: don't forget to turn on seed inference with `seeds = true` in the `Anchor.toml` file.
 
 Once the instruction runs, we then fetch the `movieReview` account and check that the data stored on the account match the expected values.
 

--- a/content/intro-to-anchor-frontend.md
+++ b/content/intro-to-anchor-frontend.md
@@ -187,7 +187,7 @@ The `AnchorProvider` constructor takes three parameters:
 - `wallet` - the `Wallet` object
 - `opts` - optional parameter that specifies the confirmation options, using a default setting if one is not provided
 
-Once you’ve create the `Provider` object, you then set it as the default provider using `setProvider`.
+Once you’ve created the `Provider` object, you then set it as the default provider using `setProvider`.
 
 ```tsx
 import { useAnchorWallet, useConnection } from "@solana/wallet-adapter-react"
@@ -209,7 +209,7 @@ Once you have the IDL and a provider, you can create an instance of `Program`. T
 
 The `Program` object creates a custom API you can use to interact with a Solana program. This API is the one stop shop for all things related to communicating with onchain programs. Among other things, you can send transactions, fetch deserialized accounts, decode instruction data, subscribe to account changes, and listen to events. You can also [learn more about the `Program` class](https://coral-xyz.github.io/anchor/ts/classes/Program.html#constructor).
 
-To create the `Program` object, first import `Program` and `Idl` from `@coral-xyz/anchor`. `Idl` is a type you can used when working with Typescript.
+To create the `Program` object, first import `Program` and `Idl` from `@coral-xyz/anchor`. `Idl` is a type you can use when working with Typescript.
 
 Next, specify the `programId` of the program. We have to explicitly state the `programId` since there can be multiple programs with the same IDL structure (i.e. if the same program is deployed multiple times using different addresses). When creating the `Program` object, the default `Provider` is used if one is not explicitly specified.
 
@@ -329,7 +329,7 @@ Alternatively, you can also get the deserialized account data for a specific acc
 const account = await program.account.counter.fetch(ACCOUNT_ADDRESS)
 ```
 
-Similarly, you can fetch for multiple accounts using `fetchMultiple`.
+Similarly, you can fetch multiple accounts using `fetchMultiple`.
 
 ```tsx
 const accounts = await program.account.counter.fetchMultiple([ACCOUNT_ADDRESS_ONE, ACCOUNT_ADDRESS_TWO])
@@ -446,7 +446,7 @@ export const Increment: FC<Props> = ({ counter, setTransactionUrl }) => {
 Next, let’s use the Anchor `MethodsBuilder` to build a new instruction to invoke the `increment` instruction. Again, Anchor can infer the `user` account from the wallet so we only need to include the `counter` account.
 
 ```tsx
-const onClick = async () => {
+const incrementCount = async () => {
   const sig = await program.methods
     .increment()
     .accounts({
@@ -459,7 +459,7 @@ const onClick = async () => {
 }
 ```
 
-### 5. Display the correct count
+### 4. Display the correct count
 
 Now that we can initialize the counter program and increment the count, we need to get our UI to show the count stored in the counter account.
 

--- a/content/intro-to-anchor.md
+++ b/content/intro-to-anchor.md
@@ -548,7 +548,7 @@ it("Is initialized!", async () => {
     .rpc()
 
   const account = await program.account.counter.fetch(counter.publicKey)
-  expect(account.count.toNumber() === 0)
+  expect(account.count.toNumber()).to.equal(0)
 })
 ```
 
@@ -562,7 +562,7 @@ it("Incremented the count", async () => {
     .rpc()
 
   const account = await program.account.counter.fetch(counter.publicKey)
-  expect(account.count.toNumber() === 1)
+  expect(account.count.toNumber()).to.equal(1)
 })
 ```
 


### PR DESCRIPTION
Hi, a few typos/issues I found while exploring the Anchor module

All typos are straight forward I guess 
For other changes:
- anchor-cpi.md l.369: missing comma, causing an error message not necessarily easy to understand
- anchor-cpi.md l.395: imports not explicitly specified (found in solution repo)
- anchor-cpi.md l.425: not working in anchor-lang >=0.29 as the syntax for getting the bump was updated
- anchor-cpi.md l.528: chai's expect(a === b) doesn't seem to fail if false (need to use: expect(a).to.equal(b)) + rearranged in proper actual/expected order


- anchor-pdas.md l.364: program always called `anchor_movie_review_program` in other parts of the lesson/template code
- anchor-pdas.md l.546: unused `assert` import
- anchor-pdas.md l.578: `seeds = true` discussed in the Lesson section but never explicitly told to enable in the Lab
- anchor-pdas.md l.588: same chai's expect changes


- intro-to-anchor-frontend.md l.449: increment function is called `incrementCount` in the starter code
- intro-to-anchor-frontend.md l.462: two sections '5' and no '4'


- intro-to-anchor.md l.551: same chai's expect changes