### PR TITLE
Typos in the 'Beyond the Basics' module

### DIFF
--- a/content/env-variables.md
+++ b/content/env-variables.md
@@ -51,7 +51,7 @@ anchor test -- --features "feature-one", "feature-two"
 
 ### Make code conditional using the `cfg` attribute
 
-With a feature defined, you can then use the `cfg` attribute within your code to conditionally compile code based on the whether or not a given feature is enabled. This allows you to include or exclude certain code from your program.
+With a feature defined, you can then use the `cfg` attribute within your code to conditionally compile code based on whether or not a given feature is enabled. This allows you to include or exclude certain code from your program.
 
 The syntax for using the `cfg` attribute is like any other attribute macro: `#[cfg(feature=[FEATURE_HERE])]`. For example, the following code compiles the function `function_for_testing` when the `testing` feature is enabled and the `function_when_not_testing` otherwise:
 
@@ -69,7 +69,7 @@ fn function_when_not_testing() {
 
 This allows you to enable or disable certain functionality in your Anchor program at compile time by enabling or disabling the feature.
 
-It's not a stretch to imagine wanting to use this to create distinct "environments" for different program deployments. For example, not all tokens have deployments across both Mainnet and Devnet. So you might hard-code one token address for Mainnet deployments but hard-code a different address for Devnet and Localnet deployments. That way you can quickly switch between between different environments without requiring any changes to the code itself.
+It's not a stretch to imagine wanting to use this to create distinct "environments" for different program deployments. For example, not all tokens have deployments across both Mainnet and Devnet. So you might hard-code one token address for Mainnet deployments but hard-code a different address for Devnet and Localnet deployments. That way you can quickly switch between different environments without requiring any changes to the code itself.
 
 The code below shows an example of an Anchor program that uses the `cfg` attribute to include different token addresses for local testing compared to other deployments:
 
@@ -159,7 +159,7 @@ For example, if your NFT staking program has to pivot and use a different reward
 
 First, you need to structure your program to store the values you anticipate changing in an account rather than hard-coding them into the program code.
 
-Next, you need to ensure that this account can only be updated by some known program authority, or what we're calling an admin. That means any instructions that modify the data on this account need to have constraints limiting who can sign for the instruction. This sounds fairly straightforward in theory, but there is one main issues: how does the program know who is an authorized admin?
+Next, you need to ensure that this account can only be updated by some known program authority, or what we're calling an admin. That means any instructions that modify the data on this account need to have constraints limiting who can sign for the instruction. This sounds fairly straightforward in theory, but there is one main issue: how does the program know who is an authorized admin?
 
 Well, there are a few solutions, each with their own benefits and drawbacks:
 
@@ -303,7 +303,7 @@ Download the starter code from the `starter` branch of [this repository](http
 
 Let's quickly walk through how the program works.
 
-The `lib.rs` file includes a constant for the USDC address and a single `payment` instruction. The `payment` instruction simply called the `payment_handler` function in the `instructions/payment.rs` file where the instruction logic is contained.
+The `lib.rs` file includes a constant for the USDC address and a single `payment` instruction. The `payment` instruction simply calls the `payment_handler` function in the `instructions/payment.rs` file where the instruction logic is contained.
 
 The `instructions/payment.rs` file contains both the `payment_handler` function as well as the `Payment` account validation struct representing the accounts required by the `payment` instruction. The `payment_handler` function calculates a 1% fee from the payment amount, transfers the fee to a designated token account, and transfers the remaining amount to the payment recipient.
 
@@ -699,7 +699,7 @@ Next, update the test file with three more tests testing that:
 1. The program config account is initialized correctly
 2. The payment instruction is functioning as intended
 3. The config account can be updated successfully by the admin
-4. The config account cannot be updated by another other than the admin
+4. The config account cannot be updated by someone other than the admin
 
 The first test initializes the program config account and verifies that the correct fee is set and that the correct admin is stored on the program config account.
 

--- a/content/rust-macros.md
+++ b/content/rust-macros.md
@@ -8,7 +8,7 @@ objectives:
 
 # Summary
 
--   **Procedural macros** are a special kind of Rust macro that allow the programmer to generate code at compile time based on custom input.
+-   **Procedural macros** are a special kind of Rust macros that allow the programmer to generate code at compile time based on custom input.
 -   In the Anchor framework, procedural macros are used to generate code that reduces the amount of boilerplate required when writing Solana programs.
 -   An **Abstract Syntax Tree (AST)** is a representation of the syntax and structure of the input code that is passed to a procedural macro. When creating a macro, you use elements of the AST like tokens and items to generate the appropriate code.
 -   A **Token** is the smallest unit of source code that can be parsed by the compiler in Rust.
@@ -60,7 +60,7 @@ You can [read more about Rust items](https://doc.rust-lang.org/reference/items.h
 
 ### Token Streams
 
-The `TokenStream` type is a data type that represents a sequence of tokens. This type is defined in the `proc_macro` crate and is surfaced as a way for you write macros based on other code in the codebase.
+The `TokenStream` type is a data type that represents a sequence of tokens. This type is defined in the `proc_macro` crate and is surfaced as a way for you to write macros based on other code in the codebase.
 
 When defining a procedural macro, the macro input is passed to the macro as a `TokenStream`, which can then be parsed and transformed as needed. The resulting `TokenStream` can then be expanded into the final code output by the macro.
 
@@ -81,7 +81,7 @@ The macro can use the AST to analyze the input code and make changes to it, such
 
 ### The `syn` crate
 
-The `syn` crate is available to help parse a token stream into an AST that macro code can traverse and manipulate. When a procedural macro is invoked in a Rust program, the macro function is called with the a token stream as the input. Parsing this input is the first step to virtually any macro.
+The `syn` crate is available to help parse a token stream into an AST that macro code can traverse and manipulate. When a procedural macro is invoked in a Rust program, the macro function is called with a token stream as the input. Parsing this input is the first step to virtually any macro.
 
 Take as an example a proc macro that you invoke using `my_macro!`as follows:
 
@@ -214,7 +214,7 @@ For example, an attribute macro could process the arguments passed to the attrib
 
 ### Derive macros
 
-Derive macros are invoked using the `#[derive]` attribute on a struct, enum, or union are typically used to automatically implement traits for the input types.
+Derive macros are invoked using the `#[derive]` attribute on a struct, enum, or union. They are typically used to automatically implement traits for the input types.
 
 ```rust
 #[derive(MyMacro)]
@@ -459,7 +459,7 @@ pub fn derive_anchor_deserialize(item: TokenStream) -> TokenStream {
 
 ### Attribute macro `#[program]`
 
-The `#[program]` attribute macro is an example of an attribute macro used in the Anchor to define the module containing instruction handlers for a Solana program.
+The `#[program]` attribute macro is an example of an attribute macro used in Anchor to define the module containing instruction handlers for a Solana program.
 
 ```rust
 #[program]

--- a/content/solana-pay.md
+++ b/content/solana-pay.md
@@ -16,13 +16,13 @@ objectives:
 
 The Solana community is continually improving and expanding the network's functionality. But that doesn't always mean developing brand new technology. Sometimes it means leveraging the network's existing features in new and interesting ways.
 
-Solana Pay is a great example of this. Rather than add new functionality to the network, Solana Pay uses the network's existing signing features in a unique way to enable merchants and applications to request transactions and build gating mechanisms for specific transaction types.
+Solana Pay is a great example of this. Rather than adding new functionality to the network, Solana Pay uses the network's existing signing features in a unique way to enable merchants and applications to request transactions and build gating mechanisms for specific transaction types.
 
 Throughout this lesson, you'll learn how to use Solana Pay to create transfer and transaction requests, encode these requests as a QR code, partially sign transactions, and gate transactions based on conditions you choose. Rather than leaving it at that, we hope you'll see this as an example of leveraging existing features in new and interesting ways, using it as a launching pad for your own unique client-side network interactions.
 
 ## Solana Pay
 
-The [Solana Pay specification](https://docs.solanapay.com/spec) is a set standards that allow users to request payments and initiate transactions using URLs in a uniform way across various Solana apps and wallets.
+The [Solana Pay specification](https://docs.solanapay.com/spec) is a set of standards that allow users to request payments and initiate transactions using URLs in a uniform way across various Solana apps and wallets.
 
 Request URLs are prefixed with `solana:` so that platforms can direct the link to the appropriate application. For example, on mobile a URL that starts with `solana:` will be directed to wallet applications that support the Solana Pay specification. From there, the wallet can use the remainder of the URL to appropriately handle the request.
 

--- a/content/solana-pay.md
+++ b/content/solana-pay.md
@@ -288,7 +288,7 @@ Now that you've got a conceptual grasp on Solana Pay, let's put it into practice
 
 ### 1. Starter
 
-To get started, download the starter code on the `starter` branch of this [repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter). The starter code is a Next.js app that displays a Solana Pay QR code. Notice that the menu bar lets you switch between different QR codes. The default option is a simple SOL transfer for illustrative purposes. Throughout  We'll be adding functionality to the location options in the menu bar.
+To get started, download the starter code on the `starter` branch of this [repository](https://github.com/Unboxed-Software/solana-scavenger-hunt-app/tree/starter). The starter code is a Next.js app that displays a Solana Pay QR code. Notice that the menu bar lets you switch between different QR codes. The default option is a simple SOL transfer for illustrative purposes. Throughout this lab, we'll be adding functionality to the location options in the menu bar.
 
 ![Screenshot of scavenger hunt app](../assets/scavenger-hunt-screenshot.png)
 

--- a/content/versioned-transaction.md
+++ b/content/versioned-transaction.md
@@ -29,13 +29,13 @@ Versioned transactions don't require any modifications to existing Solana progra
 
 ## Versioned Transactions
 
-One of the items taking up the most space Solana transactions is the inclusion of full account addresses. At 32 bytes each, 39 accounts will render a transaction too large. That's not even accounting for instruction data. In practice, most transactions will be too large with around 20 accounts.
+One of the items taking up the most space in Solana transactions is the inclusion of full account addresses. At 32 bytes each, 39 accounts will render a transaction too large. That's not even accounting for instruction data. In practice, most transactions will be too large with around 20 accounts.
 
 Solana released versioned transactions to support multiple transaction formats. Alongside the release of versioned transactions, Solana released version 0 of transactions to support Address Lookup Tables. Lookup tables are separate accounts that store account addresses and then allow them to be referenced in a transaction using a 1 byte index. This significantly decreases the size of a transaction since each included account now only needs to use 1 byte instead of 32 bytes.
 
 Even if you don't need to use lookup tables, you'll need to know how to support versioned transactions in your client-side code. Fortunately, everything you need to work with versioned transactions and lookup tables is included in the `@solana/web3.js` library.
 
-### Create versioned transaction
+### Create versioned transactions
 
 To create a versioned transaction, you simply create a `TransactionMessage` with the following parameters:
 
@@ -68,7 +68,7 @@ const message = new web3.TransactionMessage({
 }).compileToV0Message();
 ```
 
-Finally, you pass the compiled message into `VersionedTransaction` constructor to create a new versioned transaction. Your code can then sign and send the transaction to the network, similar to a legacy transaction.
+Finally, you pass the compiled message into the `VersionedTransaction` constructor to create a new versioned transaction. Your code can then sign and send the transaction to the network, similar to a legacy transaction.
 
 ```typescript
 // Create the versioned transaction using the message
@@ -167,7 +167,7 @@ Note that when extending a lookup table, the number of addresses that can be add
 
 ### Send Transaction
 
-After creating the instructions, you can add them to a transaction and sent to the network.
+After creating the instructions, you can add them to a transaction and sent it to the network.
 
 ```typescript
 // Get the latest blockhash
@@ -190,7 +190,7 @@ transaction.sign([payer]);
 const transactionSignature = await connection.sendTransaction(transaction);
 ```
 
-Note that when you first create or extend a lookup table or when, it needs to "warm up" for one slot before the LUT or new addresses can be used in transactions. In other words, you can only use a lookup tables and access addresses that were added prior to the current slot.
+Note that when you first create or extend a lookup table, it needs to "warm up" for one slot before the LUT or new addresses can be used in transactions. In other words, you can only use lookup tables and access addresses that were added prior to the current slot.
 
 ```typescript
 SendTransactionError: failed to send transaction: invalid transaction: Transaction address table lookup uses an invalid index
@@ -200,7 +200,7 @@ If you encounter the error above or are unable to access addresses in a lookup t
 
 ### Deactivate a lookup table
 
-When an lookup table is no longer needed, you can deactivate and close it to reclaim its rent balance. Address lookup tables can be deactivated at any time, but they can continue to be used by transactions until a specified "deactivation" slot is no longer "recent". This "cool-down" period ensures that in-flight transactions can't be censored by LUTs being closed and recreated in the same slot. The deactivation period is approximately 513 slots.
+When a lookup table is no longer needed, you can deactivate and close it to reclaim its rent balance. Address lookup tables can be deactivated at any time, but they can continue to be used by transactions until a specified "deactivation" slot is no longer "recent". This "cool-down" period ensures that in-flight transactions can't be censored by LUTs being closed and recreated in the same slot. The deactivation period is approximately 513 slots.
 
 To deactivate an LUT, use the `deactivateLookupTable` method and pass in the following parameters:
 
@@ -587,7 +587,7 @@ async function main() {
 
 Notice that you create the transfer instructions with the full recipient address even though we created a lookup table. That's because by including the lookup table in the versioned transaction, you tell the `web3.js` framework to replace any recipient addresses that match addresses in the lookup table with pointers to the lookup table instead. By the time the transaction is sent to the network, addresses that exist in the lookup table will be referenced by a single byte rather than the full 32 bytes.
 
-Use `npm start` in the command line to execute the `main` function. You should see output similar to the following:
+Use `npm start` in the command line to execute the `main` function. You should see an output similar to the following:
 
 ```bash
 Current balance is 1.38866636
@@ -609,7 +609,7 @@ Keep in mind that the solution we've come up with so far only supports transfers
 
 All we need to do is go into `initializeLookupTable` and do two things:
 
-1. Modify the existing call to `extendLookupTable` to only add the first 30 addressess (any more than that and the transaction will be too large)
+1. Modify the existing call to `extendLookupTable` to only add the first 30 addresses (any more than that and the transaction will be too large)
 2. Add a loop that will keep extending a lookup table 30 addresses at a time until all addresses have been added
 
 ```typescript


### PR DESCRIPTION
Hey, just a few typos in the 'Beyond the Basics' module. Great lessons again, thanks!

FYI the rust-macros starter repo still seems be missing (cf. #329) and makes the lesson a bit harder to complete
