### PR TITLE
Refer to Solana Foundation developer content repo for Style Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you'd like to add content, please start by [creating an issue](https://github
 
 Once a plan has been discussed and agreed to, you can start working on content. 
 
-When you're done, create a PR for the `main`` branch.
+When you're done, create a PR for the `main` branch.
 
 Create new modules in the same format as the existing modules - see [Getting Started](./content/getting-started.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,78 +25,9 @@ If you want to fix a typo or otherwise improve on existing content, follow a sim
 1. [Create an issue](https://github.com/Unboxed-Software/solana-course/issues/new) and/or comment on an existing issue to state you've started working
 2. Create a PR to the `draft` branch during or when complete
 
-### Guidelines
+## Style guide 
 
-The guidelines below are consistent with Solana Foundation Style, to ensure consistency with other content on solana.com. There are also a few additional items aimed at technical documents. 
-
-Use language consistent with [TERMINOLOGY](https://github.com/solana-foundation/developer-content/blob/main/docs/terminology.md) and (if you have access to this) the Solana Foundation Style Guide. 
-
-In particular:
-
-- Use sentence case for headlines (”Solana Foundation announces new initiative” instead of “Solana Foundation Announces New Initiative”).
-- Use 'secret key' rather than 'private key' to be consistent with web3.js. __Note__: this will change in a future version of web3.js. 
-- Use 'wallet app' for software. 'wallet' for the address that holds value.
-- Use 'onchain' (not on-chain, definitely not smart contract) when referring to onchain apps. This comes from the Solana Foundation style guide, and is intended to be similar to 'online'. 
-- Use 'SOL' rather than 'Sol' to refer to Solana's native token. Definitely don't call it Solana!
-- PDAs are not public keys. It is not possible to have a public key without a secret key. A public key is derived from a secret key, and it is not possible to generate a public key without first generating a secret key.
-- Use the terms 'blockchain' or 'web3' rather than 'crypto'.
-- Be careful about the term 'token account'. A ['token account' is any account formatted to hold tokens](https://solana.stackexchange.com/questions/7507/what-is-the-difference-between-a-token-account-and-an-associated-token-account), and being specific (rather than, for example, swapping between 'associated token account' and 'token account') makes this clearer. 
-  - Use the specific term 'associated token account' rather than just 'token account' if you're referring to an account at an associated token address.  
-  - Use 'token mint account' to refer to the address where a token is minted. E.g., the [USDC mainnet token mint account](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
-Use apostrophes of possession, [including for inanimate objects](https://english.stackexchange.com/questions/1031/is-using-the-possessive-s-correct-in-the-cars-antenna). Eg 'the account's balance' is correct.
-- Don't use 'here' links. They make the course hard to scan and ['here' links are bad for SEO](https://www.smashingmagazine.com/2012/06/links-should-never-say-click-here/).
-- JS/TS clients send `transactions` made from `instructions`. Onchain programs have `instruction handlers` that process `instructions`. Do not refer to [instruction handlers](https://solana.com/docs/terminology#instruction-handler) as instructions! The reason is simple: an instruction cannot process an instruction. The `multiple` template in Anchor 0.29 also calls the actual functions `handler`.
-
-Code examples should be formatted as follows:
-
-### Code
-
-You're writing code to be read, understood, and changed by others.
-
-We want the minimal amount of code necessary to solve the problem.
- 
- - Use full names. Call a `thing` a `thing`. Don't call it a `thg`. Avoid repetitive, copy-paste code. This helps others change the code easily, as they can fix things in a single place.
- - Avoid magic numbers. Nobody should see a `+ 32` in your code and wonder what the `32` means.
- - Avoid asking students to clone a git repo. The idea is that students should be able to create projects from scratch when they have finished the course. Referring to the code students have made in previous chapters is fine. 
-  - `esrun` means you don't need to set up `tsconfig.json` files just to run TypeScript code. 
-  - Tools like `anchor init` or `create-solana-dapp` are fine. 
-  - If there's some boilerplate, Solana-specific code you always need [make a PR to the helpers repository](https://github.com/solana-developers/helpers).
-
-### JS/TS
-
-We're trying to focus on Solana, not teaching JS/TS development and setup. This means reducing the JS/TS concepts needed to understand our demo code.
-
- - `ts` files are run with `esrun`, which supports top-level `await`, doesn't require a `tsconfig.json`, etc. There is no need for `async function main()` wrappers or [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). `await` just works. If you see these wrappers, delete them.
-
- - Likewise, use async/await and use try / catch all the time, rather than sometimes using `.then()` and `.catch()`
-
- - Throw errors with `throw new Error('message')`. Don't throw strings (JS allows almost any type to be thrown). TS code can assume anything thrown is of the `Error` type. 
-
- - Don't make custom helper functions. Instead, use the `@solana-developers/helpers` package. If you need a function that doesn't exist, make a PR to `@solana-developers/helpers`, and add the helper, tests, and docs.
-
- - Use two spaces per prettier defaults, StandardJS, node style guide, idiomatic JS, AirBnB style guide, MDN, Google Style guide, codepen, jsfiddle, etc.
-
- - Write tests so we can run your code and ensure a new release of something doesn't break your code. Ensure your tests make sense. BDD style (which Anchor uses by default) uses `describe` and `it` to create the names. So `describe('the plus operator', () => {}` becomes `describe the plus operation` and `it('adds numbers', () => {...})` becomes `it adds numbers`.  Ensure your test names make sense!
-
-### Rust & Anchor
-
- - Use the [multiple files template](https://www.anchor-lang.com/docs/release-notes#multiple-files-template) to organize Anchor projects. 
-
- - Avoid magic numbers. People reading your code should be able to understand where values come from. Use [InitSpace](https://docs.rs/anchor-lang/latest/anchor_lang/derive.InitSpace.html) to calculate space needed for accounts, and add a constant `DISCRIMINATOR_SIZE` to `constants.rs`.
-
-  - Bad: `8 + 32 + 32 + 8 + 8`
-
-  - Good: `space = DISCRIMINATOR_SIZE + SomeAccount::INIT_SPACE,` 
-
- - Use four spaces per `rustfmt`.
-
-##  Diagrams:
-
-- If you draw Solana elliptic curves, these are [Edwards curves](https://en.wikipedia.org/wiki/Edwards_curve)
-- Use [Whimsical](https://whimsical.com/) for diagrams
-- Use SVG where possible (they'll look better on different screens). You can get an SVG export from Whimsical by appending `/svg` to the end of a Whimsical URL.
- 
-Note that while `prettier` can format Markdown, [prettier doesn't support language-specific settings inside Markdown files](https://github.com/prettier/prettier/issues/5378) so you'll need to format the code yourself for now.
+Prose and code in this repo should follow the [Solana Developer Content Contributing Guide](https://github.com/solana-foundation/developer-content/blob/main/CONTRIBUTING.md) style.
 
 ## Committing
 


### PR DESCRIPTION
(Created as a draft PR pending the merge of https://github.com/solana-foundation/developer-content/pull/201)

Right now there's two separate CONTRIBUTING guides, this one and a newer one created by Developer Relations. We can probably make it one, so [merge the style guide from this repo](https://github.com/solana-foundation/developer-content/pull/201) and then link there.

