### PR TITLE
Move native-specific serialization/deserialization into Native module

### DIFF
--- a/content/deserialize-custom-data.md
+++ b/content/deserialize-custom-data.md
@@ -18,11 +18,12 @@ objectives:
 # Lesson
 
 In the last lesson, we serialized program data that was subsequently stored onchain by a Solana program. In this lesson, we’ll cover in greater detail how programs store data on the chain, how to retrieve data, and how to deserialize the data they store.
+
 ## Programs
 
 As the saying goes, everything in Solana is an account. Even programs. Programs are accounts that store code and are marked as executable. This code can be executed by the Solana runtime when instructed to do so. A program address is a public keys on the Ed25519 Elliptic Curve. Like all public keys, they have corresponding secret keys.
 
-Programs store data seperately from their code. Programs store data in PDAs, which stands for **Program Derived Address**. PDAs are a unique concept to Solana, but the pattern is familiar: 
+Programs store data separately from their code. Programs store data in PDAs, which stands for **Program Derived Address**. PDAs are a unique concept to Solana, but the pattern is familiar: 
 
  - You can think of PDAs as a key value store, where the address is the key, and the data inside the account is the value.
  - You can also consider PDAs as records in a database, with the address being the primary key used to look up the values inside.
@@ -216,7 +217,7 @@ The method first checks whether or not the buffer exists and returns `null` if i
 
 Now that we have a way to deserialize account data, we need to actually fetch the accounts. Open `MovieList.tsx` and import `@solana/web3.js`. Then, create a new `Connection` inside the `MovieList` component. Finally, replace the line `setMovies(Movie.mocks)` inside `useEffect` with a call to `connection.getProgramAccounts`. Take the resulting array and convert it into an array of movies and call `setMovies`.
 
-```typescript
+```tsx
 import { Card } from './Card'
 import { FC, useEffect, useState } from 'react'
 import { Movie } from '../models/Movie'

--- a/course-structure.json
+++ b/course-structure.json
@@ -48,21 +48,6 @@
                             "title": "Interact with wallets",
                             "slug": "interact-with-wallets",
                             "lab": "Make a React frontend to the Ping program"
-                        },
-                        {
-                            "title": "Serialize program data",
-                            "slug": "serialize-instruction-data",
-                            "lab": "Build a React frontend to submit movie reviews"
-                        },
-                        {
-                            "title": "Deserialize program data",
-                            "slug": "deserialize-custom-data",
-                            "lab": "Build a React frontend to show movie reviews"
-                        },
-                        {
-                            "title": "Page, Order, and Filter program data",
-                            "slug": "paging-ordering-filtering-data",
-                            "lab": "Adding paging, ordering and searching to the movie reviews frontend"
                         }
                     ]
                 },
@@ -134,6 +119,21 @@
                     "title": "Native Solana Program Development",
                     "slug": "basic-solana-program-development",
                     "lessons": [
+                        {
+                            "title": "Serialize program data",
+                            "slug": "serialize-instruction-data",
+                            "lab": "Build a React frontend to submit movie reviews"
+                        },
+                        {
+                            "title": "Deserialize program data",
+                            "slug": "deserialize-custom-data",
+                            "lab": "Build a React frontend to show movie reviews"
+                        },
+                        {
+                            "title": "Page, Order, and Filter program data",
+                            "slug": "paging-ordering-filtering-data",
+                            "lab": "Adding paging, ordering and searching to the movie reviews frontend"
+                        },
                         {
                             "title": "Hello World in native",
                             "slug": "hello-world-program",


### PR DESCRIPTION
Right now the opening module has a bunch of serialization/deserialization work that's not relevant for the vast majority of new users. Fixes https://github.com/Unboxed-Software/solana-course/issues/353

Plus minor grammar fixes and a small tweak to the intro so it makes explains why this is relevant to native development.

