### PR TITLE
Adding info about last argument of airDropIfRequired()

### DIFF
--- a/content/intro-to-writing-data.md
+++ b/content/intro-to-writing-data.md
@@ -106,7 +106,8 @@ await airdropIfRequired(
 );
 ```
 
-This will deposit 1 SOL into your account which you can use for testing. This won’t work on Mainnet where it would have value. But it's incredibly convenient for testing locally and on Devnet.
+This will deposit 1 SOL into your account if your balance is below 0.5 SOL, which you can use for testing.
+This won’t work on Mainnet where it would have value. But it's incredibly convenient for testing locally and on Devnet.
 
 You can also use the Solana CLI command `solana airdrop 1` to get free test SOL in your account when testing, whether locally or on devnet.
 


### PR DESCRIPTION

Related issue: https://github.com/Unboxed-Software/solana-course/issues/380

I'm thinking by adding a bit of explanation on the last argument, it will make it more clear to the reader (saving time for them so they don't need to browse & peruse the docs to understand). 
